### PR TITLE
Simplify main menu for cleaner navigation

### DIFF
--- a/terminal_arcade/main.py
+++ b/terminal_arcade/main.py
@@ -1,31 +1,17 @@
 """Terminal Arcade - Main Entry Point.
 
-Launches the splash screen and main menu system.
+Launches the main menu system for games, tools, and demos.
 """
 
 import sys
 from pathlib import Path
-from .engine.renderer import Renderer
-from .engine.input_handler import InputHandler
-from .launcher.splash_screen import SplashScreen
 from .launcher.game_registry import GameRegistry, GameCategory
 from .launcher.main_menu import EnhancedMenu
 
 
 def main():
     """Main entry point for Terminal Arcade."""
-    # Get base path
     base_path = Path(__file__).parent
-
-    # Initialize input handler to check joystick
-    input_handler = InputHandler()
-    joystick_detected = input_handler.verify_joystick()['connected']
-    input_handler.cleanup()
-
-    # Show splash screen
-    renderer = Renderer()
-    splash = SplashScreen(renderer)
-    splash.show(duration=2.0, joystick_detected=joystick_detected)
 
     # Initialize game registry
     registry = GameRegistry(base_path)
@@ -35,26 +21,20 @@ def main():
     tools_dir = base_path / "tools"
     demos_dir = base_path / "demos"
 
-    # Scan directories
     registry.scan_directory(games_dir, GameCategory.ARCADE_GAME)
     registry.scan_directory(tools_dir, GameCategory.CREATIVE_TOOL)
     registry.scan_directory(demos_dir, GameCategory.VISUAL_DEMO)
 
-    # Check if any games were found
     if not registry.has_games():
-        print("No games found! Please check the installation.")
-        print(f"Searched in:")
-        print(f"  - {games_dir}")
-        print(f"  - {tools_dir}")
-        print(f"  - {demos_dir}")
+        print("No games found! Check installation.")
+        print(f"Searched: {games_dir}, {tools_dir}, {demos_dir}")
         sys.exit(1)
 
-    # Show main menu
+    # Run menu
     menu = EnhancedMenu(registry)
     menu.run()
 
-    print("\nThanks for playing Terminal Arcade!")
-    print("Visit: https://github.com/jcaldwell-labs/terminal-arcade")
+    print("\nThanks for playing!")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Remove ASCII art logo, use simple "TERMINAL ARCADE" title
- Remove decorative section headers, use plain category labels
- Remove emoji indicators from game list
- Show description only for selected item in footer area
- Skip splash screen for faster startup
- Keep keyboard and joystick navigation support

## Before
- Large ASCII art banner
- Section headers with `═══` borders
- Emoji indicators (⭐, 🎮, ⌨️) on each item
- Descriptions shown inline for all items
- 2-second splash screen delay

## After
- Clean "TERMINAL ARCADE" title
- Simple category labels (ARCADE GAMES, CREATIVE TOOLS, etc.)
- Plain text item list with `>` selector
- Description shown only for selected item in footer
- Instant menu launch

## Test plan
- [ ] Run `python -m terminal_arcade.main`
- [ ] Verify menu fits on 80x24 terminal
- [ ] Test keyboard navigation (arrows + enter)
- [ ] Test joystick navigation if available
- [ ] Verify category grouping visible
- [ ] Verify description updates when navigating

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)