### PR TITLE
feat: Add input script recorder for demo video generation (#82)

### DIFF
--- a/atari_style/core/input_recorder.py
+++ b/atari_style/core/input_recorder.py
@@ -19,9 +19,9 @@ import argparse
 import json
 import sys
 import time
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 from .input_handler import InputHandler
 
@@ -50,6 +50,9 @@ class InputRecorder:
     Captures joystick axis positions and button states at a specified
     sample rate, outputting a script compatible with ScriptedInputHandler.
     """
+
+    # Threshold for digital quantization (-1, 0, 1)
+    DIGITAL_THRESHOLD = 0.5
 
     def __init__(
         self,
@@ -80,9 +83,9 @@ class InputRecorder:
 
     def _quantize(self, value: float) -> float:
         """Quantize analog value to digital (-1, 0, 1)."""
-        if value > 0.5:
+        if value > self.DIGITAL_THRESHOLD:
             return 1.0
-        elif value < -0.5:
+        elif value < -self.DIGITAL_THRESHOLD:
             return -1.0
         return 0.0
 


### PR DESCRIPTION
## Summary

Adds a CLI tool that captures live joystick input and saves it as a JSON script file compatible with the demo video export system.

- Records joystick axes (x, y) and button states at configurable fps
- `--duration`: Set recording length in seconds
- `--fps`: Sample rate (default 30)
- `--digital`: Quantize analog to -1/0/1 for digital sticks
- `--sparse`: Only save keyframes on state changes (smaller files)
- Real-time progress display with frame counter and input state
- Countdown before recording starts
- Ctrl+C to stop early

## Usage

```bash
# Basic recording
python -m atari_style.core.input_recorder --duration 15 -o demo.json

# Sparse mode (smaller files)
python -m atari_style.core.input_recorder -d 30 --sparse -o sparse.json

# Digital joystick mode
python -m atari_style.core.input_recorder -d 10 --digital -o digital.json

# Use recording with demo_video
python -m atari_style.core.demo_video joystick_test demo.json -o output.mp4
```

## Output Format

```json
{
  "name": "Recorded Input",
  "duration": 15.0,
  "fps": 30,
  "interpolation": "smooth",
  "keyframes": [
    {"time": 0.0, "x": 0.0, "y": 0.0, "buttons": []},
    {"time": 0.5, "x": 1.0, "y": 0.0, "buttons": [0]},
    ...
  ]
}
```

## Test plan

- [x] Module imports correctly
- [x] CLI help displays properly
- [x] 14 unit tests pass (keyframes, quantization, state detection, save/load)
- [ ] Manual test: Record with physical joystick
- [ ] Verify output works with `demo_video.py`

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)