### PR TITLE
refactor: Shared font loading utility

### DIFF
--- a/atari_style/core/headless_renderer.py
+++ b/atari_style/core/headless_renderer.py
@@ -27,6 +27,8 @@ except ImportError:
     ImageDraw = None
     ImageFont = None
 
+from atari_style.utils.fonts import load_monospace_font
+
 
 # ANSI color names to RGB values
 # Based on typical terminal color schemes (close to Ubuntu/VSCode defaults)
@@ -127,35 +129,8 @@ class HeadlessRenderer:
     def _load_font(self, font_path: Optional[str]) -> 'ImageFont.FreeTypeFont':
         """Load monospace font for rendering."""
         font_size = self.char_height - 4  # Leave some padding
-
-        if font_path and Path(font_path).exists():
-            try:
-                return ImageFont.truetype(font_path, font_size)
-            except Exception:
-                pass  # Fall through to defaults
-
-        # Try common monospace fonts
-        font_candidates = [
-            '/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf',
-            '/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf',
-            '/usr/share/fonts/truetype/ubuntu/UbuntuMono-R.ttf',
-            '/usr/share/fonts/TTF/DejaVuSansMono.ttf',
-            '/System/Library/Fonts/Menlo.ttc',  # macOS
-            'C:/Windows/Fonts/consola.ttf',  # Windows
-        ]
-
-        for candidate in font_candidates:
-            if Path(candidate).exists():
-                try:
-                    return ImageFont.truetype(candidate, font_size)
-                except Exception:
-                    continue
-
-        # Fall back to default (may not be monospace)
-        try:
-            return ImageFont.load_default()
-        except Exception:
-            return None
+        preferred = [font_path] if font_path else None
+        return load_monospace_font(font_size, preferred_paths=preferred)
 
     def _color_to_rgb(self, color: Optional[str]) -> Tuple[int, int, int]:
         """Convert color name to RGB tuple."""

--- a/atari_style/demos/visualizers/composite_video_renderer.py
+++ b/atari_style/demos/visualizers/composite_video_renderer.py
@@ -4,7 +4,8 @@ import os
 import time
 import subprocess
 import math
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
+from atari_style.utils.fonts import load_monospace_font
 
 
 # ANSI color to RGB mapping (Dracula-like theme)
@@ -86,13 +87,7 @@ class CompositeVideoRenderer:
         self.mock_renderer = MockRenderer(width, height)
 
         # Load monospace font
-        try:
-            self.font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 22)
-        except (IOError, OSError):
-            try:
-                self.font = ImageFont.truetype("/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf", 22)
-            except (IOError, OSError):
-                self.font = ImageFont.load_default()
+        self.font = load_monospace_font(22)
 
         # Background color (Dracula)
         self.bg_color = (40, 42, 54)

--- a/atari_style/demos/visualizers/explorer_renderer.py
+++ b/atari_style/demos/visualizers/explorer_renderer.py
@@ -8,7 +8,8 @@ import os
 import time
 import math
 import subprocess
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
+from atari_style.utils.fonts import load_monospace_font
 
 from .interestingness_tracker import InterestingnessTracker, InterestingnessBounds
 
@@ -74,12 +75,8 @@ class ExplorerRenderer:
         self.img_width = width * self.cell_width
         self.img_height = height * self.cell_height
 
-        try:
-            self.font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 20)
-            self.font_small = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 16)
-        except (IOError, OSError):
-            self.font = ImageFont.load_default()
-            self.font_small = self.font
+        self.font = load_monospace_font(20)
+        self.font_small = load_monospace_font(16)
 
         self.bg_color = (40, 42, 54)
 

--- a/atari_style/demos/visualizers/gimbal_renderer.py
+++ b/atari_style/demos/visualizers/gimbal_renderer.py
@@ -11,7 +11,8 @@ import os
 import time
 import math
 import subprocess
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
+from atari_style.utils.fonts import load_monospace_font
 from ...core.renderer import Color
 
 
@@ -85,10 +86,7 @@ class GimbalRenderer:
         self.mock_renderer = MockRenderer(width, height)
         self.bg_color = (15, 20, 35)  # Deep space blue
 
-        try:
-            self.font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 22)
-        except (IOError, OSError):
-            self.font = ImageFont.load_default()
+        self.font = load_monospace_font(22)
 
     def render_frame(self) -> Image.Image:
         img = Image.new('RGB', (self.img_width, self.img_height), self.bg_color)

--- a/atari_style/demos/visualizers/self_tuning_renderer.py
+++ b/atari_style/demos/visualizers/self_tuning_renderer.py
@@ -8,7 +8,8 @@ import os
 import time
 import math
 import subprocess
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
+from atari_style.utils.fonts import load_monospace_font
 
 from .interestingness_tracker import (
     InterestingnessTracker, InterestingnessBounds,
@@ -83,13 +84,7 @@ class SelfTuningVideoRenderer:
         self.mock_renderer = MockRenderer(width, height)
 
         # Load font
-        try:
-            self.font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 22)
-        except (IOError, OSError):
-            try:
-                self.font = ImageFont.truetype("/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf", 22)
-            except (IOError, OSError):
-                self.font = ImageFont.load_default()
+        self.font = load_monospace_font(22)
 
         self.bg_color = (40, 42, 54)
 

--- a/atari_style/demos/visualizers/themed_renderer.py
+++ b/atari_style/demos/visualizers/themed_renderer.py
@@ -4,7 +4,8 @@ import os
 import time
 import math
 import subprocess
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
+from atari_style.utils.fonts import load_monospace_font
 from ...core.renderer import Color
 
 
@@ -92,10 +93,7 @@ class ThemedVideoRenderer:
         self.mock_renderer = MockRenderer(width, height)
         self.bg_color = THEME_BG.get(theme, (40, 42, 54))
 
-        try:
-            self.font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 22)
-        except (IOError, OSError):
-            self.font = ImageFont.load_default()
+        self.font = load_monospace_font(22)
 
     def render_frame(self) -> Image.Image:
         img = Image.new('RGB', (self.img_width, self.img_height), self.bg_color)

--- a/atari_style/utils/__init__.py
+++ b/atari_style/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities for atari-style."""

--- a/atari_style/utils/fonts.py
+++ b/atari_style/utils/fonts.py
@@ -1,0 +1,63 @@
+"""Shared font loading utility for consistent monospace font resolution.
+
+Centralizes the font loading cascade pattern used across renderers,
+eliminating duplicated try/except blocks and ensuring cross-platform
+font discovery.
+
+Usage:
+    from atari_style.utils.fonts import load_monospace_font
+
+    font = load_monospace_font(22)
+    font = load_monospace_font(16, preferred_paths=['/my/custom/font.ttf'])
+"""
+
+import logging
+from typing import Optional
+
+from PIL import ImageFont
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_FONT_PATHS = [
+    '/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf',
+    '/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf',
+    '/usr/share/fonts/truetype/ubuntu/UbuntuMono-R.ttf',
+    '/usr/share/fonts/TTF/DejaVuSansMono.ttf',
+    '/System/Library/Fonts/Menlo.ttc',
+    'C:/Windows/Fonts/consola.ttf',
+]
+
+
+def load_monospace_font(
+    size: int,
+    preferred_paths: Optional[list[str]] = None,
+) -> 'ImageFont.FreeTypeFont':
+    """Load a monospace font, trying paths in order with a fallback.
+
+    Attempts to load a TrueType monospace font by iterating through
+    preferred paths first, then the default cross-platform paths.
+    Falls back to PIL's built-in default font if no TrueType font
+    is found.
+
+    Args:
+        size: Font size in points.
+        preferred_paths: Optional list of font file paths to try before
+            the defaults.
+
+    Returns:
+        A PIL ImageFont instance. May be the built-in bitmap font if
+        no TrueType fonts were found.
+    """
+    candidates = list(preferred_paths or []) + DEFAULT_FONT_PATHS
+
+    for path in candidates:
+        try:
+            return ImageFont.truetype(path, size)
+        except OSError:
+            continue
+
+    logger.warning(
+        "No monospace TrueType font found; falling back to PIL default. "
+        "Text rendering may not be monospaced."
+    )
+    return ImageFont.load_default()

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,0 +1,85 @@
+"""Tests for the shared font loading utility."""
+
+import logging
+import unittest
+from unittest.mock import patch, MagicMock
+
+from atari_style.utils.fonts import load_monospace_font, DEFAULT_FONT_PATHS
+
+
+class TestLoadMonospaceFont(unittest.TestCase):
+    """Tests for load_monospace_font()."""
+
+    @patch("atari_style.utils.fonts.ImageFont")
+    def test_loads_first_available_default_path(self, mock_image_font):
+        """Should return a TrueType font from the first working default path."""
+        sentinel = MagicMock(name="truetype_font")
+        mock_image_font.truetype.return_value = sentinel
+
+        result = load_monospace_font(22)
+
+        mock_image_font.truetype.assert_called_once_with(DEFAULT_FONT_PATHS[0], 22)
+        self.assertIs(result, sentinel)
+
+    @patch("atari_style.utils.fonts.ImageFont")
+    def test_tries_paths_in_order(self, mock_image_font):
+        """Should skip paths that raise OSError and try the next."""
+        sentinel = MagicMock(name="truetype_font")
+        mock_image_font.truetype.side_effect = [OSError, OSError, sentinel]
+
+        result = load_monospace_font(16)
+
+        self.assertIs(result, sentinel)
+        self.assertEqual(mock_image_font.truetype.call_count, 3)
+
+    @patch("atari_style.utils.fonts.ImageFont")
+    def test_fallback_to_default_when_no_paths_work(self, mock_image_font):
+        """Should fall back to load_default() when all truetype paths fail."""
+        mock_image_font.truetype.side_effect = OSError
+        default_font = MagicMock(name="default_font")
+        mock_image_font.load_default.return_value = default_font
+
+        result = load_monospace_font(20)
+
+        mock_image_font.load_default.assert_called_once()
+        self.assertIs(result, default_font)
+
+    @patch("atari_style.utils.fonts.ImageFont")
+    def test_custom_preferred_paths_tried_first(self, mock_image_font):
+        """Should try preferred_paths before DEFAULT_FONT_PATHS."""
+        sentinel = MagicMock(name="truetype_font")
+        mock_image_font.truetype.side_effect = [OSError, sentinel]
+        custom_paths = ["/nonexistent/font.ttf", "/my/custom/font.ttf"]
+
+        result = load_monospace_font(18, preferred_paths=custom_paths)
+
+        self.assertIs(result, sentinel)
+        # Second call should be the second custom path
+        self.assertEqual(
+            mock_image_font.truetype.call_args_list[1][0],
+            ("/my/custom/font.ttf", 18),
+        )
+
+    @patch("atari_style.utils.fonts.ImageFont")
+    def test_logs_warning_on_fallback(self, mock_image_font):
+        """Should log a warning when falling back to the default font."""
+        mock_image_font.truetype.side_effect = OSError
+        mock_image_font.load_default.return_value = MagicMock()
+
+        with self.assertLogs("atari_style.utils.fonts", level=logging.WARNING) as cm:
+            load_monospace_font(20)
+
+        self.assertTrue(any("fallback" in msg.lower() or "falling back" in msg.lower()
+                            for msg in cm.output))
+
+    @patch("atari_style.utils.fonts.ImageFont")
+    def test_no_warning_when_font_found(self, mock_image_font):
+        """Should not log a warning when a TrueType font is successfully loaded."""
+        mock_image_font.truetype.return_value = MagicMock()
+
+        with self.assertNoLogs("atari_style.utils.fonts", level=logging.WARNING):
+            load_monospace_font(22)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Creates `atari_style/utils/fonts.py` with `load_monospace_font(size, preferred_paths)` that centralizes the font loading cascade pattern duplicated across 6 renderer files
- Replaces bare `except:` clauses with specific `OSError` handling and adds a logged warning on fallback to PIL's default font
- Updates `composite_video_renderer.py`, `explorer_renderer.py`, `gimbal_renderer.py`, `themed_renderer.py`, `self_tuning_renderer.py`, and `headless_renderer.py` to use the shared utility

## Test plan
- [x] Added 6 unit tests in `tests/test_fonts.py` covering: valid path loading, path iteration order, fallback behavior, custom preferred paths, warning logging, and no-warning on success
- [x] All 6 new tests pass
- [x] `ruff check` passes on all modified files
- [x] Full test suite passes (318 tests; 2 pre-existing pytest import errors unrelated to this change)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)