### PR TITLE
feat: Add Claugger game, blog article, project docs, and publish workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,45 @@
+name: Publish Docs to Site
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/blog/**'
+      - 'docs/site/**'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Determine changed content
+        id: changes
+        run: |
+          blog_changed=false
+          docs_changed=false
+          if git diff --name-only HEAD~1 HEAD | grep -q '^docs/blog/'; then
+            blog_changed=true
+          fi
+          if git diff --name-only HEAD~1 HEAD | grep -q '^docs/site/'; then
+            docs_changed=true
+          fi
+          echo "blog=$blog_changed" >> "$GITHUB_OUTPUT"
+          echo "docs=$docs_changed" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch to site repo
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_PUBLISH_TOKEN }}
+          repository: jcaldwell-labs/jcaldwell-labs.github.io
+          event-type: publish-atari-style-docs
+          client-payload: |
+            {
+              "source_repo": "${{ github.repository }}",
+              "source_ref": "${{ github.sha }}",
+              "blog_changed": "${{ steps.changes.outputs.blog }}",
+              "docs_changed": "${{ steps.changes.outputs.docs }}"
+            }

--- a/atari_style/demos/games/claugger.py
+++ b/atari_style/demos/games/claugger.py
@@ -1098,9 +1098,14 @@ class Claugger:
             self.renderer.draw_text(cx, cy, msg, Color.BRIGHT_YELLOW)
             self.renderer.render()
 
-            # Re-query dimensions on each check (blessed updates term.width/height)
-            self.renderer.width = self.renderer.term.width
-            self.renderer.height = self.renderer.term.height
+            # Re-query dimensions and rebuild buffer to match
+            new_w = self.renderer.term.width
+            new_h = self.renderer.term.height
+            if new_w != self.renderer.width or new_h != self.renderer.height:
+                self.renderer.width = new_w
+                self.renderer.height = new_h
+                self.renderer.buffer = [[' ' for _ in range(new_w)] for _ in range(new_h)]
+                self.renderer.color_buffer = [[None for _ in range(new_w)] for _ in range(new_h)]
 
             if self._check_terminal_size():
                 return True
@@ -1116,6 +1121,14 @@ class Claugger:
     def run(self) -> None:
         """Enter fullscreen and run the game loop until the user quits."""
         self.renderer.enter_fullscreen()
+        # Re-sync buffer to actual terminal size after entering fullscreen
+        new_w = self.renderer.term.width
+        new_h = self.renderer.term.height
+        if new_w != self.renderer.width or new_h != self.renderer.height:
+            self.renderer.width = new_w
+            self.renderer.height = new_h
+            self.renderer.buffer = [[' ' for _ in range(new_w)] for _ in range(new_h)]
+            self.renderer.color_buffer = [[None for _ in range(new_w)] for _ in range(new_h)]
         try:
             # Check terminal dimensions before starting
             if not self._check_terminal_size():

--- a/atari_style/demos/games/claugger.py
+++ b/atari_style/demos/games/claugger.py
@@ -131,6 +131,25 @@ class Lane:
     objects: List[LaneObject] = field(default_factory=list)
 
 
+@dataclass
+class Egg:
+    """An egg laid by the chicken on a lane.
+
+    Args:
+        x: Horizontal position of the egg.
+        lane: Lane index where the egg was laid.
+        attached_object: The river object this egg rides on, or None for road eggs.
+        squashed: True when a vehicle has run over this egg.
+        splat_timer: Elapsed time since squashing (for removal delay).
+    """
+
+    x: float
+    lane: int
+    attached_object: LaneObject = None
+    squashed: bool = False
+    splat_timer: float = 0.0
+
+
 # ---------------------------------------------------------------------------
 # Main game class
 # ---------------------------------------------------------------------------
@@ -192,6 +211,10 @@ class Claugger:
         # HUD message (level complete, etc.)
         self._hud_message: str = ""
         self._hud_message_timer: float = 0.0
+
+        # Egg system
+        self.eggs: List[Egg] = []
+        self.total_eggs_laid: int = 0
 
     # ------------------------------------------------------------------
     # Lane construction
@@ -368,6 +391,118 @@ class Claugger:
 
         if moved:
             self.chicken_hop_timer = 0.1
+            self.try_lay_egg()
+
+    # ------------------------------------------------------------------
+    # Egg system
+    # ------------------------------------------------------------------
+
+    def try_lay_egg(self) -> None:
+        """Attempt to lay an egg with a 5% chance per hop.
+
+        Eggs are not laid on SAFE, START, or GOAL lanes.
+        """
+        lane = self.lanes[self.chicken_lane]
+        if lane.lane_type in (LaneType.SAFE, LaneType.START, LaneType.GOAL):
+            return
+        if random.random() < 0.05:
+            self.lay_egg()
+
+    def lay_egg(self) -> None:
+        """Lay an egg at the chicken's current position.
+
+        For RIVER lanes, the egg is attached to whichever object the chicken
+        is standing on (so it scrolls with the object).  Increments
+        total_eggs_laid and awards an extra life every 10 eggs.
+        """
+        lane = self.lanes[self.chicken_lane]
+        attached: LaneObject = None
+
+        if lane.lane_type == LaneType.RIVER:
+            chicken_left = self.chicken_x
+            chicken_right = self.chicken_x + CHICKEN_WIDTH
+            for obj in lane.objects:
+                obj_left = obj.x
+                obj_right = obj.x + obj.width
+                if chicken_left < obj_right and chicken_right > obj_left and not obj.is_diving:
+                    attached = obj
+                    break
+
+        egg = Egg(x=float(self.chicken_x), lane=self.chicken_lane, attached_object=attached)
+        self.eggs.append(egg)
+        self.total_eggs_laid += 1
+
+        if self.total_eggs_laid % 10 == 0:
+            self.lives += 1
+            self._hud_message = "EGGS-tra life!"
+            self._hud_message_timer = 2.0
+
+    def lay_egg_at(self, lane: int, x: float) -> None:
+        """Place an egg deterministically at a given lane and x position.
+
+        This helper is used by tests and special game events. It does not
+        increment total_eggs_laid or check for extra-life milestones.
+
+        Args:
+            lane: Lane index for the egg.
+            x: Horizontal position of the egg.
+        """
+        egg = Egg(x=x, lane=lane)
+        self.eggs.append(egg)
+
+    def update_eggs(self, dt: float) -> None:
+        """Update all eggs: check for vehicle squashing and river scrolling.
+
+        Road eggs: destroyed when a vehicle bounding box overlaps the egg x.
+        River eggs: x position follows their attached_object; removed when the
+        object scrolls off-screen.
+        Squashed eggs linger for 0.5 s (splat animation) then are removed.
+
+        Args:
+            dt: Delta time in seconds since the last update.
+        """
+        eggs_to_remove = []
+
+        for egg in self.eggs:
+            if egg.squashed:
+                egg.splat_timer += dt
+                if egg.splat_timer >= 0.5:
+                    eggs_to_remove.append(egg)
+                continue
+
+            lane = self.lanes[egg.lane]
+
+            if lane.lane_type == LaneType.ROAD:
+                for obj in lane.objects:
+                    obj_left = obj.x
+                    obj_right = obj.x + obj.width
+                    # Egg is a single-character point; check if egg.x falls inside obj
+                    if obj_left <= egg.x < obj_right:
+                        egg.squashed = True
+                        break
+
+            elif lane.lane_type == LaneType.RIVER and egg.attached_object is not None:
+                obj = egg.attached_object
+                egg.x = obj.x
+                # Remove if object scrolled fully off-screen
+                if obj.x + obj.width < 0 or obj.x >= SCREEN_WIDTH:
+                    eggs_to_remove.append(egg)
+
+        for egg in eggs_to_remove:
+            if egg in self.eggs:
+                self.eggs.remove(egg)
+
+    def score_eggs(self) -> int:
+        """Score all surviving (non-squashed) eggs at 200 points each.
+
+        Clears the egg list after scoring.
+
+        Returns:
+            Total points awarded for surviving eggs.
+        """
+        points = sum(200 for egg in self.eggs if not egg.squashed)
+        self.eggs.clear()
+        return points
 
     # ------------------------------------------------------------------
     # Collision detection
@@ -439,6 +574,7 @@ class Claugger:
         self.nests_filled += 1
 
         if self.nests_filled >= 5:
+            self.score += self.score_eggs()
             self.state = Claugger.STATE_LEVEL_COMPLETE
             self._level_complete_timer = 2.0
             self._hud_message = f"EGG-cellent! Level {self.level} complete!"
@@ -601,6 +737,7 @@ class Claugger:
         # Update turtle dives, river riding, then collisions
         self.update_turtle_dives(dt)
         self.update_river_riding(dt)
+        self.update_eggs(dt)
         self.check_collisions()
 
         # Auto-fill nest when chicken reaches the GOAL lane
@@ -699,6 +836,17 @@ class Claugger:
                 self.renderer.draw_text(int(self.chicken_x), sprite_top_row, sprite_rows[0], chicken_color)
             if sprite_bot_row < term_height - HUD_ROWS - 1:
                 self.renderer.draw_text(int(self.chicken_x), sprite_bot_row, sprite_rows[1], chicken_color)
+
+        # Draw eggs
+        for egg in self.eggs:
+            visual_lane = LANE_COUNT - 1 - egg.lane
+            egg_row = field_top + visual_lane * ROWS_PER_LANE + 1
+            egg_x = int(egg.x)
+            if 0 <= egg_x < SCREEN_WIDTH and egg_row < term_height - HUD_ROWS - 1:
+                if egg.squashed:
+                    self.renderer.set_pixel(egg_x, egg_row, "*", Color.BRIGHT_RED)
+                else:
+                    self.renderer.set_pixel(egg_x, egg_row, "o", Color.YELLOW)
 
         # HUD rows at the bottom
         hud_y = term_height - HUD_ROWS

--- a/atari_style/demos/games/claugger.py
+++ b/atari_style/demos/games/claugger.py
@@ -155,9 +155,24 @@ class Claugger:
     def __init__(self) -> None:
         self.renderer = Renderer()
         self.input_handler = InputHandler()
-        self.lanes: List[Lane] = self._build_lanes(level=1)
         self.last_time: float = time.time()
         self.running: bool = True
+
+        # Scoring / progression
+        self.score: int = 0
+        self.lives: int = 3
+        self.level: int = 1
+        self.timer: float = 60.0
+        self.nests_filled: int = 0
+        self.nests: List[bool] = [False] * 5
+
+        # Tracks the highest lane reached this life (prevents re-scoring same lane)
+        self.highest_lane_this_life: int = 0
+
+        # Level-complete display timer
+        self._level_complete_timer: float = 0.0
+
+        self.lanes: List[Lane] = self._build_lanes(level=1)
 
         # Game state
         self.state: int = Claugger.STATE_PLAYING
@@ -173,6 +188,10 @@ class Claugger:
         self.death_type: str = ""
         self.death_timer: float = 0.0
         self.death_message: str = ""
+
+        # HUD message (level complete, etc.)
+        self._hud_message: str = ""
+        self._hud_message_timer: float = 0.0
 
     # ------------------------------------------------------------------
     # Lane construction
@@ -326,6 +345,11 @@ class Claugger:
             if new_lane != self.chicken_lane:
                 self.chicken_lane = new_lane
                 moved = True
+                # Award 10 points per new highest lane reached
+                if dy > 0 and self.chicken_lane > self.highest_lane_this_life:
+                    points = (self.chicken_lane - self.highest_lane_this_life) * 10
+                    self.score += points
+                    self.highest_lane_this_life = self.chicken_lane
             if dy > 0:
                 self.chicken_facing = "up"
             else:
@@ -397,6 +421,48 @@ class Claugger:
             self.death_message = random.choice(DEATH_MESSAGES)
 
     # ------------------------------------------------------------------
+    # Nest filling and level progression
+    # ------------------------------------------------------------------
+
+    def fill_nest(self) -> None:
+        """Fill the current nest when the chicken reaches the GOAL lane.
+
+        Awards 50 base points plus a time bonus equal to twice the remaining
+        timer seconds.  After filling, the chicken respawns at lane 0 without
+        resetting the timer.  When all 5 nests are filled the game transitions
+        to STATE_LEVEL_COMPLETE.
+        """
+        time_bonus = int(self.timer * 2)
+        self.score += 50 + time_bonus
+
+        self.nests[self.nests_filled] = True
+        self.nests_filled += 1
+
+        if self.nests_filled >= 5:
+            self.state = Claugger.STATE_LEVEL_COMPLETE
+            self._level_complete_timer = 2.0
+            self._hud_message = f"EGG-cellent! Level {self.level} complete!"
+            self._hud_message_timer = 2.0
+        else:
+            # Respawn without resetting the timer
+            _saved_timer = self.timer
+            self._respawn_chicken()
+            self.timer = _saved_timer
+
+    def next_level(self) -> None:
+        """Advance to the next level, rebuilding lanes with increased speed.
+
+        Increments the level counter, rebuilds lane objects scaled to the new
+        level, resets nest state, resets the timer, and respawns the chicken.
+        """
+        self.level += 1
+        self.lanes = self._build_lanes(self.level)
+        self.nests = [False] * 5
+        self.nests_filled = 0
+        self._respawn_chicken()
+        self.state = Claugger.STATE_PLAYING
+
+    # ------------------------------------------------------------------
     # River riding
     # ------------------------------------------------------------------
 
@@ -463,10 +529,12 @@ class Claugger:
     # ------------------------------------------------------------------
 
     def _respawn_chicken(self) -> None:
-        """Reset the chicken to the starting position."""
+        """Reset the chicken to the starting position and restore the timer."""
         self.chicken_x = (SCREEN_WIDTH - CHICKEN_WIDTH) // 2
         self.chicken_lane = 0
         self.chicken_facing = "up"
+        self.timer = 60.0
+        self.highest_lane_this_life = 0
 
     def update(self, dt: float) -> None:
         """Advance game state for one frame.
@@ -486,8 +554,30 @@ class Claugger:
                 self.state = Claugger.STATE_PLAYING
             return
 
+        if self.state == Claugger.STATE_LEVEL_COMPLETE:
+            self._level_complete_timer -= dt
+            if self._level_complete_timer <= 0.0:
+                self.next_level()
+            return
+
         if self.state != Claugger.STATE_PLAYING:
             return
+
+        # Count down egg timer
+        self.timer -= dt
+        if self.timer <= 0.0:
+            self.timer = 0.0
+            self.state = Claugger.STATE_DYING
+            self.death_type = "timeout"
+            self.death_timer = 1.5
+            self.death_message = random.choice(DEATH_MESSAGES)
+            return
+
+        # Decay HUD message timer
+        if self._hud_message_timer > 0.0:
+            self._hud_message_timer -= dt
+            if self._hud_message_timer <= 0.0:
+                self._hud_message = ""
 
         # Scroll lane objects
         for lane in self.lanes:
@@ -512,6 +602,10 @@ class Claugger:
         self.update_turtle_dives(dt)
         self.update_river_riding(dt)
         self.check_collisions()
+
+        # Auto-fill nest when chicken reaches the GOAL lane
+        if self.state == Claugger.STATE_PLAYING and self.chicken_lane == LANE_COUNT - 1:
+            self.fill_nest()
 
     def draw(self) -> None:
         """Render all lanes and their scrolling objects to the terminal buffer.
@@ -609,11 +703,29 @@ class Claugger:
         # HUD rows at the bottom
         hud_y = term_height - HUD_ROWS
         self.renderer.draw_text(0, hud_y, "─" * SCREEN_WIDTH, Color.BRIGHT_WHITE)
-        self.renderer.draw_text(
-            2, hud_y + 1,
-            "CLAUGGER  |  Arrows/WASD: Move  |  Q/ESC: Quit",
-            Color.BRIGHT_YELLOW,
-        )
+
+        # Row 1: Score (left), Level (center), Lives (right)
+        score_text = f"EGGS-cellent: {self.score:,}"
+        level_text = f"Crossing #{self.level}"
+        lives_text = ">Q< " * self.lives
+
+        level_x = max(0, (SCREEN_WIDTH - len(level_text)) // 2)
+        lives_x = max(0, SCREEN_WIDTH - len(lives_text))
+
+        self.renderer.draw_text(2, hud_y + 1, score_text, Color.BRIGHT_YELLOW)
+        self.renderer.draw_text(level_x, hud_y + 1, level_text, Color.BRIGHT_CYAN)
+        self.renderer.draw_text(lives_x, hud_y + 1, lives_text, Color.BRIGHT_GREEN)
+
+        # Row 2: Egg timer bar + HUD message
+        bar_width = 40
+        filled = int(bar_width * max(0.0, self.timer) / 60.0)
+        timer_bar = "█" * filled + "░" * (bar_width - filled)
+        timer_label = f"Egg Timer: [{timer_bar}]"
+        self.renderer.draw_text(2, hud_y + 2, timer_label, Color.BRIGHT_RED)
+
+        if self._hud_message:
+            msg_x = max(0, SCREEN_WIDTH - len(self._hud_message) - 2)
+            self.renderer.draw_text(msg_x, hud_y + 2, self._hud_message, Color.BRIGHT_MAGENTA)
 
         self.renderer.render()
 

--- a/atari_style/demos/games/claugger.py
+++ b/atari_style/demos/games/claugger.py
@@ -4,7 +4,7 @@ import time
 import random
 from enum import Enum
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 from ...core.renderer import Renderer, Color
 from ...core.input_handler import InputHandler, InputType
 
@@ -69,6 +69,14 @@ DEATH_MESSAGES = [
     "That's not how you cross the road!",
     "Hen-ded!",
     "Clucked out!",
+]
+
+KONAMI_SEQUENCE = [
+    InputType.UP, InputType.UP,
+    InputType.DOWN, InputType.DOWN,
+    InputType.LEFT, InputType.RIGHT,
+    InputType.LEFT, InputType.RIGHT,
+    InputType.SELECT, InputType.BACK,
 ]
 
 # ---------------------------------------------------------------------------
@@ -194,7 +202,7 @@ class Claugger:
         self.lanes: List[Lane] = self._build_lanes(level=1)
 
         # Game state
-        self.state: int = Claugger.STATE_PLAYING
+        self.state: int = Claugger.STATE_TITLE
 
         # Chicken state
         self.chicken_x: int = (SCREEN_WIDTH - CHICKEN_WIDTH) // 2
@@ -215,6 +223,45 @@ class Claugger:
         # Egg system
         self.eggs: List[Egg] = []
         self.total_eggs_laid: int = 0
+
+        # Konami Code / Easter eggs
+        self.input_buffer: list = []
+        self.golden_rooster_active: bool = False
+        self.golden_rooster_used: bool = False
+        self.golden_rooster_timer: float = 5.0
+
+        # Road Scholar achievement
+        self.consecutive_deathless_levels: int = 0
+        self.deaths_this_level: int = 0
+        self.road_scholar_triggered: bool = False
+
+    # ------------------------------------------------------------------
+    # Easter egg helpers
+    # ------------------------------------------------------------------
+
+    def record_input(self, input_type: InputType) -> None:
+        """Record an input into the Konami Code rolling buffer.
+
+        Appends the input to a rolling buffer of the last 10 inputs. If the
+        buffer matches the Konami sequence and the golden rooster has not been
+        used this session, the golden rooster mode is activated.
+
+        Args:
+            input_type: The InputType value to record.
+        """
+        self.input_buffer.append(input_type)
+        if len(self.input_buffer) > len(KONAMI_SEQUENCE):
+            self.input_buffer = self.input_buffer[-len(KONAMI_SEQUENCE):]
+
+        if (
+            self.input_buffer == KONAMI_SEQUENCE
+            and not self.golden_rooster_used
+        ):
+            self.golden_rooster_active = True
+            self.golden_rooster_used = True
+            self.golden_rooster_timer = 5.0
+            self._hud_message = "COCKA-DOODLE-CHEAT!"
+            self._hud_message_timer = 3.0
 
     # ------------------------------------------------------------------
     # Lane construction
@@ -508,6 +555,22 @@ class Claugger:
     # Collision detection
     # ------------------------------------------------------------------
 
+    def _trigger_death(self, death_type: str) -> None:
+        """Transition to STATE_DYING and track death count.
+
+        Skip collision effects when golden rooster is active (invincibility).
+
+        Args:
+            death_type: "squash", "drown", or "timeout".
+        """
+        if self.golden_rooster_active:
+            return
+        self.state = Claugger.STATE_DYING
+        self.death_type = death_type
+        self.death_timer = 1.5
+        self.death_message = random.choice(DEATH_MESSAGES)
+        self.deaths_this_level += 1
+
     def check_collisions(self) -> None:
         """Check for collisions between the chicken and lane objects.
 
@@ -529,10 +592,7 @@ class Claugger:
                 obj_right = obj.x + obj.width
                 # Bounding box overlap: intervals overlap when left < other_right and right > other_left
                 if chicken_left < obj_right and chicken_right > obj_left:
-                    self.state = Claugger.STATE_DYING
-                    self.death_type = "squash"
-                    self.death_timer = 1.5
-                    self.death_message = random.choice(DEATH_MESSAGES)
+                    self._trigger_death("squash")
                     return
 
         elif lane.lane_type == LaneType.RIVER:
@@ -543,17 +603,11 @@ class Claugger:
                 if chicken_left < obj_right and chicken_right > obj_left:
                     # Overlapping an object — check if it's a diving turtle
                     if obj.is_diving:
-                        self.state = Claugger.STATE_DYING
-                        self.death_type = "drown"
-                        self.death_timer = 1.5
-                        self.death_message = random.choice(DEATH_MESSAGES)
+                        self._trigger_death("drown")
                     # Otherwise safe — found a valid platform
                     return
             # No overlap with any object → drown
-            self.state = Claugger.STATE_DYING
-            self.death_type = "drown"
-            self.death_timer = 1.5
-            self.death_message = random.choice(DEATH_MESSAGES)
+            self._trigger_death("drown")
 
     # ------------------------------------------------------------------
     # Nest filling and level progression
@@ -590,7 +644,23 @@ class Claugger:
 
         Increments the level counter, rebuilds lane objects scaled to the new
         level, resets nest state, resets the timer, and respawns the chicken.
+        Also checks the Road Scholar achievement: 3 consecutive deathless levels
+        award 5000 bonus points.
         """
+        # Road Scholar tracking
+        if self.deaths_this_level == 0:
+            self.consecutive_deathless_levels += 1
+        else:
+            self.consecutive_deathless_levels = 0
+
+        if self.consecutive_deathless_levels >= 3 and not self.road_scholar_triggered:
+            self.road_scholar_triggered = True
+            self.score += 5000
+            self._hud_message = "Why did the chicken cross the road? To get to the other SIDE of knowledge!"
+            self._hud_message_timer = 4.0
+
+        self.deaths_this_level = 0
+
         self.level += 1
         self.lanes = self._build_lanes(self.level)
         self.nests = [False] * 5
@@ -686,8 +756,12 @@ class Claugger:
         if self.state == Claugger.STATE_DYING:
             self.death_timer -= dt
             if self.death_timer <= 0.0:
-                self._respawn_chicken()
-                self.state = Claugger.STATE_PLAYING
+                self.lives -= 1
+                if self.lives <= 0:
+                    self.state = Claugger.STATE_GAME_OVER
+                else:
+                    self._respawn_chicken()
+                    self.state = Claugger.STATE_PLAYING
             return
 
         if self.state == Claugger.STATE_LEVEL_COMPLETE:
@@ -696,17 +770,23 @@ class Claugger:
                 self.next_level()
             return
 
+        if self.state in (Claugger.STATE_TITLE, Claugger.STATE_GAME_OVER):
+            return
+
         if self.state != Claugger.STATE_PLAYING:
             return
+
+        # Golden rooster countdown (invincibility timer)
+        if self.golden_rooster_active:
+            self.golden_rooster_timer -= dt
+            if self.golden_rooster_timer <= 0.0:
+                self.golden_rooster_active = False
 
         # Count down egg timer
         self.timer -= dt
         if self.timer <= 0.0:
             self.timer = 0.0
-            self.state = Claugger.STATE_DYING
-            self.death_type = "timeout"
-            self.death_timer = 1.5
-            self.death_message = random.choice(DEATH_MESSAGES)
+            self._trigger_death("timeout")
             return
 
         # Decay HUD message timer
@@ -744,6 +824,109 @@ class Claugger:
         if self.state == Claugger.STATE_PLAYING and self.chicken_lane == LANE_COUNT - 1:
             self.fill_nest()
 
+    def _draw_title_screen(self) -> None:
+        """Render the title screen with ASCII art and prompt."""
+        self.renderer.clear_buffer()
+        term_height = self.renderer.height
+        term_width = self.renderer.width
+
+        title_art = [
+            " ██████╗██╗      █████╗ ██╗   ██╗ ██████╗  ██████╗ ███████╗██████╗ ",
+            "██╔════╝██║     ██╔══██╗██║   ██║██╔════╝ ██╔════╝ ██╔════╝██╔══██╗",
+            "██║     ██║     ███████║██║   ██║██║  ███╗██║  ███╗█████╗  ██████╔╝",
+            "██║     ██║     ██╔══██║██║   ██║██║   ██║██║   ██║██╔══╝  ██╔══██╗",
+            "╚██████╗███████╗██║  ██║╚██████╔╝╚██████╔╝╚██████╔╝███████╗██║  ██║",
+            " ╚═════╝╚══════╝╚═╝  ╚═╝ ╚═════╝  ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝",
+        ]
+        chicken_art = [
+            "   >Q<   ",
+            "   /|\\   ",
+            "  / | \\  ",
+        ]
+        start_y = max(1, term_height // 2 - 8)
+
+        for i, line in enumerate(title_art):
+            x = max(0, (term_width - len(line)) // 2)
+            self.renderer.draw_text(x, start_y + i, line, Color.BRIGHT_YELLOW)
+
+        chk_y = start_y + len(title_art) + 1
+        for i, line in enumerate(chicken_art):
+            x = max(0, (term_width - len(line)) // 2)
+            self.renderer.draw_text(x, chk_y + i, line, Color.BRIGHT_GREEN)
+
+        tagline = "Why did the chicken cross the road?"
+        press_enter = "Press ENTER to start"
+        quit_hint = "Press Q to quit"
+
+        tl_x = max(0, (term_width - len(tagline)) // 2)
+        pe_x = max(0, (term_width - len(press_enter)) // 2)
+        qi_x = max(0, (term_width - len(quit_hint)) // 2)
+
+        self.renderer.draw_text(tl_x, chk_y + len(chicken_art) + 1, tagline, Color.CYAN)
+        self.renderer.draw_text(pe_x, chk_y + len(chicken_art) + 3, press_enter, Color.BRIGHT_WHITE)
+        self.renderer.draw_text(qi_x, chk_y + len(chicken_art) + 4, quit_hint, Color.BRIGHT_BLACK)
+
+        self.renderer.render()
+
+    def _draw_game_over_screen(self) -> None:
+        """Render the game over screen with final stats."""
+        self.renderer.clear_buffer()
+        term_height = self.renderer.height
+        term_width = self.renderer.width
+
+        header = "THE ROOST IS COOKED"
+        start_y = max(1, term_height // 2 - 6)
+
+        h_x = max(0, (term_width - len(header)) // 2)
+        self.renderer.draw_text(h_x, start_y, header, Color.BRIGHT_RED)
+
+        stats = [
+            f"Final Score:  {self.score:,}",
+            f"Level Reached: {self.level}",
+            f"Eggs Laid:    {self.total_eggs_laid}",
+            f"Nests Filled: {self.nests_filled}",
+        ]
+        for i, stat in enumerate(stats):
+            sx = max(0, (term_width - len(stat)) // 2)
+            self.renderer.draw_text(sx, start_y + 2 + i, stat, Color.BRIGHT_WHITE)
+
+        play_again = "Press ENTER to play again"
+        pa_x = max(0, (term_width - len(play_again)) // 2)
+        self.renderer.draw_text(pa_x, start_y + 2 + len(stats) + 2, play_again, Color.BRIGHT_GREEN)
+
+        self.renderer.render()
+
+    def _reset_game(self) -> None:
+        """Reset all game state for a fresh playthrough."""
+        self.score = 0
+        self.lives = 3
+        self.level = 1
+        self.timer = 60.0
+        self.nests_filled = 0
+        self.nests = [False] * 5
+        self.highest_lane_this_life = 0
+        self._level_complete_timer = 0.0
+        self.lanes = self._build_lanes(level=1)
+        self.chicken_x = (SCREEN_WIDTH - CHICKEN_WIDTH) // 2
+        self.chicken_lane = 0
+        self.chicken_facing = "up"
+        self.chicken_frame = 0
+        self.chicken_hop_timer = 0.0
+        self.death_type = ""
+        self.death_timer = 0.0
+        self.death_message = ""
+        self._hud_message = ""
+        self._hud_message_timer = 0.0
+        self.eggs = []
+        self.total_eggs_laid = 0
+        self.input_buffer = []
+        self.golden_rooster_active = False
+        self.golden_rooster_used = False
+        self.golden_rooster_timer = 5.0
+        self.consecutive_deathless_levels = 0
+        self.deaths_this_level = 0
+        self.road_scholar_triggered = False
+
     def draw(self) -> None:
         """Render all lanes and their scrolling objects to the terminal buffer.
 
@@ -751,6 +934,14 @@ class Claugger:
         playing field; lane 12 (GOAL) is at the top.  A 1-row border and the
         HUD occupy the remaining rows.
         """
+        if self.state == Claugger.STATE_TITLE:
+            self._draw_title_screen()
+            return
+
+        if self.state == Claugger.STATE_GAME_OVER:
+            self._draw_game_over_screen()
+            return
+
         self.renderer.clear_buffer()
 
         term_height = self.renderer.height
@@ -941,16 +1132,29 @@ class Claugger:
                 dt = min(dt, 0.1)  # Cap to avoid spiral of death
 
                 input_type = self.input_handler.get_input(timeout=0.001)
+
+                # Always record input for Konami Code detection
+                if input_type not in (InputType.NONE, None):
+                    self.record_input(input_type)
+
                 if input_type in (InputType.BACK, InputType.QUIT):
                     running = False
-                elif input_type == InputType.UP:
-                    self.move_chicken(0, 1)
-                elif input_type == InputType.DOWN:
-                    self.move_chicken(0, -1)
-                elif input_type == InputType.LEFT:
-                    self.move_chicken(-1, 0)
-                elif input_type == InputType.RIGHT:
-                    self.move_chicken(1, 0)
+                elif self.state == Claugger.STATE_TITLE:
+                    if input_type == InputType.SELECT:
+                        self.state = Claugger.STATE_PLAYING
+                elif self.state == Claugger.STATE_GAME_OVER:
+                    if input_type == InputType.SELECT:
+                        self._reset_game()
+                        self.state = Claugger.STATE_TITLE
+                elif self.state == Claugger.STATE_PLAYING:
+                    if input_type == InputType.UP:
+                        self.move_chicken(0, 1)
+                    elif input_type == InputType.DOWN:
+                        self.move_chicken(0, -1)
+                    elif input_type == InputType.LEFT:
+                        self.move_chicken(-1, 0)
+                    elif input_type == InputType.RIGHT:
+                        self.move_chicken(1, 0)
 
                 self.update(dt)
                 self.draw()

--- a/atari_style/demos/games/claugger.py
+++ b/atari_style/demos/games/claugger.py
@@ -22,6 +22,22 @@ TARGET_FPS = 30
 SCREEN_WIDTH = 80        # Working column count
 
 # ---------------------------------------------------------------------------
+# Chicken sprite constants
+# ---------------------------------------------------------------------------
+
+CHICKEN_WIDTH = 3        # Character width of each sprite row
+
+# Each entry is a list of 2 strings (top row, bottom row), each exactly
+# CHICKEN_WIDTH characters wide.
+CHICKEN_SPRITES = {
+    "up":    [">^<", "/|\\"],
+    "down":  ["\\|/", ">v<"],
+    "left":  ["<(^", " )>"],
+    "right": ["^)>", "<( "],
+    "idle":  [">Q<", " ^ "],
+}
+
+# ---------------------------------------------------------------------------
 # Vehicle / river-object ASCII art constants
 # ---------------------------------------------------------------------------
 
@@ -125,6 +141,13 @@ class Claugger:
         self.lanes: List[Lane] = self._build_lanes(level=1)
         self.last_time: float = time.time()
         self.running: bool = True
+
+        # Chicken state
+        self.chicken_x: int = (SCREEN_WIDTH - CHICKEN_WIDTH) // 2
+        self.chicken_lane: int = 0
+        self.chicken_facing: str = "up"
+        self.chicken_frame: int = 0
+        self.chicken_hop_timer: float = 0.0
 
     # ------------------------------------------------------------------
     # Lane construction
@@ -256,6 +279,48 @@ class Claugger:
             x += random.uniform(8, 16)
 
     # ------------------------------------------------------------------
+    # Chicken movement
+    # ------------------------------------------------------------------
+
+    def move_chicken(self, dx: int, dy: int) -> None:
+        """Move the chicken by (dx, dy) steps, clamping to valid bounds.
+
+        Lane numbers run 0 (bottom/start) to 12 (top/goal).  Moving up
+        (toward the goal) passes dy=+1; moving down passes dy=-1.
+        Horizontal steps move by CHICKEN_WIDTH characters.
+
+        Args:
+            dx: Horizontal direction: +1 right, -1 left, 0 no change.
+            dy: Vertical direction: +1 up (higher lane), -1 down, 0 no change.
+        """
+        moved = False
+
+        if dy != 0:
+            new_lane = self.chicken_lane + dy
+            new_lane = max(0, min(LANE_COUNT - 1, new_lane))
+            if new_lane != self.chicken_lane:
+                self.chicken_lane = new_lane
+                moved = True
+            if dy > 0:
+                self.chicken_facing = "up"
+            else:
+                self.chicken_facing = "down"
+
+        if dx != 0:
+            new_x = self.chicken_x + dx * CHICKEN_WIDTH
+            new_x = max(0, min(SCREEN_WIDTH - CHICKEN_WIDTH, new_x))
+            if new_x != self.chicken_x:
+                self.chicken_x = new_x
+                moved = True
+            if dx > 0:
+                self.chicken_facing = "right"
+            else:
+                self.chicken_facing = "left"
+
+        if moved:
+            self.chicken_hop_timer = 0.1
+
+    # ------------------------------------------------------------------
     # Game loop helpers
     # ------------------------------------------------------------------
 
@@ -359,6 +424,21 @@ class Claugger:
         # Top border
         self.renderer.draw_text(0, 0, "─" * SCREEN_WIDTH, Color.BRIGHT_WHITE)
 
+        # --- Chicken sprite ---
+        sprite_rows = CHICKEN_SPRITES.get(self.chicken_facing, CHICKEN_SPRITES["idle"])
+        # Calculate terminal row for the chicken's lane (same formula as lanes above)
+        visual_lane = LANE_COUNT - 1 - self.chicken_lane
+        lane_row_start = field_top + visual_lane * ROWS_PER_LANE
+        # Center sprite vertically within the 3 rows of the lane (row offset 0 = top row,
+        # 1 = middle row used for the bottom sprite row so both rows fit neatly)
+        sprite_top_row = lane_row_start  # top row of sprite
+        sprite_bot_row = lane_row_start + 1  # bottom row of sprite
+        chicken_color = Color.BRIGHT_YELLOW
+        if sprite_top_row < term_height - HUD_ROWS - 1:
+            self.renderer.draw_text(self.chicken_x, sprite_top_row, sprite_rows[0], chicken_color)
+        if sprite_bot_row < term_height - HUD_ROWS - 1:
+            self.renderer.draw_text(self.chicken_x, sprite_bot_row, sprite_rows[1], chicken_color)
+
         # HUD rows at the bottom
         hud_y = term_height - HUD_ROWS
         self.renderer.draw_text(0, hud_y, "─" * SCREEN_WIDTH, Color.BRIGHT_WHITE)
@@ -436,6 +516,14 @@ class Claugger:
                 input_type = self.input_handler.get_input(timeout=0.001)
                 if input_type in (InputType.BACK, InputType.QUIT):
                     running = False
+                elif input_type == InputType.UP:
+                    self.move_chicken(0, 1)
+                elif input_type == InputType.DOWN:
+                    self.move_chicken(0, -1)
+                elif input_type == InputType.LEFT:
+                    self.move_chicken(-1, 0)
+                elif input_type == InputType.RIGHT:
+                    self.move_chicken(1, 0)
 
                 self.update(dt)
                 self.draw()

--- a/atari_style/demos/games/claugger.py
+++ b/atari_style/demos/games/claugger.py
@@ -1,0 +1,465 @@
+"""Claugger - Why did the chicken cross the road? A Frogger tribute."""
+
+import time
+import random
+from enum import Enum
+from dataclasses import dataclass, field
+from typing import List
+from ...core.renderer import Renderer, Color
+from ...core.input_handler import InputHandler, InputType
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+LANE_COUNT = 13          # Logical lanes in the game
+ROWS_PER_LANE = 3        # Each lane renders as 3 terminal rows
+HUD_ROWS = 3             # Score / status bar at the bottom
+MIN_TERM_HEIGHT = 44     # LANE_COUNT * ROWS_PER_LANE + HUD_ROWS + 2 border
+MIN_TERM_WIDTH = 80      # Classic 80-column terminal
+TARGET_FPS = 30
+
+SCREEN_WIDTH = 80        # Working column count
+
+# ---------------------------------------------------------------------------
+# Vehicle / river-object ASCII art constants
+# ---------------------------------------------------------------------------
+
+CAR_SPRITES: List[str] = [
+    "[==]",   # sedan
+    "[##]",   # truck-like car
+    "[<>]",   # sports car
+    "[--]",   # flat car
+]
+
+TRUCK_SPRITES: List[str] = [
+    "[====]",   # standard truck
+    "[####]",   # heavy truck
+    "[<===>]",  # long truck (7 chars — kept as-is, width varies)
+]
+
+MOTORCYCLE_SPRITES: List[str] = [
+    "()>",
+    "(*)",
+]
+
+LOG_CHAR = "="
+TURTLE_CHAR = "@"
+
+# ---------------------------------------------------------------------------
+# Lane type enum
+# ---------------------------------------------------------------------------
+
+
+class LaneType(Enum):
+    """Types of lanes in the Claugger playing field."""
+
+    START = "start"    # Starting platform (bottom)
+    ROAD = "road"      # Car/truck traffic
+    SAFE = "safe"      # Median / safe island
+    RIVER = "river"    # Logs and turtles
+    GOAL = "goal"      # Lily-pad goal row (top)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LaneObject:
+    """A scrolling object within a lane (car, log, turtle group, etc.).
+
+    Args:
+        x: Horizontal position (float, may be negative during wrap).
+        width: Character width of the object.
+        chars: ASCII string representing the object's visual.
+        color: Color constant string used for rendering.
+        is_diving: True when this turtle group is submerged.
+        dive_timer: Elapsed time in the current dive phase.
+        dive_phase: Total duration of current dive phase (seconds).
+    """
+
+    x: float
+    width: int
+    chars: str
+    color: str = Color.WHITE
+    is_diving: bool = False
+    dive_timer: float = 0.0
+    dive_phase: float = 0.0
+
+
+@dataclass
+class Lane:
+    """One logical lane of the playing field.
+
+    Args:
+        lane_type: Classification of this lane (ROAD, RIVER, etc.).
+        speed: Scroll speed in characters per second.
+        direction: +1 scrolls right, -1 scrolls left.
+        objects: List of scrolling objects in this lane.
+    """
+
+    lane_type: LaneType
+    speed: float
+    direction: int
+    objects: List[LaneObject] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Main game class
+# ---------------------------------------------------------------------------
+
+
+class Claugger:
+    """Claugger game — a Frogger tribute in the terminal.
+
+    Builds a 13-lane playing field with scrolling road and river objects.
+    The chicken, collision detection, and egg mechanics are not yet present;
+    this skeleton provides the world the chicken will inhabit.
+    """
+
+    def __init__(self) -> None:
+        self.renderer = Renderer()
+        self.input_handler = InputHandler()
+        self.lanes: List[Lane] = self._build_lanes(level=1)
+        self.last_time: float = time.time()
+        self.running: bool = True
+
+    # ------------------------------------------------------------------
+    # Lane construction
+    # ------------------------------------------------------------------
+
+    def _build_lanes(self, level: int) -> List[Lane]:
+        """Generate 13-lane configuration for the given level.
+
+        Lane order, index 0 = bottom of screen:
+          0        : START (home row)
+          1–5      : ROAD  (5 traffic lanes)
+          6        : SAFE  (median island)
+          7–11     : RIVER (5 water lanes)
+          12       : GOAL  (lily-pad finish row)
+
+        Args:
+            level: Current game level; higher levels increase speed.
+
+        Returns:
+            List of Lane objects ordered bottom-to-top.
+        """
+        speed_scale = 1.0 + (level - 1) * 0.2
+
+        lanes: List[Lane] = []
+
+        # --- Lane 0: START ---
+        lanes.append(Lane(lane_type=LaneType.START, speed=0.0, direction=1))
+
+        # --- Lanes 1–5: ROAD ---
+        road_configs = [
+            (2.0 * speed_scale, 1),
+            (3.0 * speed_scale, -1),
+            (2.5 * speed_scale, 1),
+            (4.0 * speed_scale, -1),
+            (3.5 * speed_scale, 1),
+        ]
+        for speed, direction in road_configs:
+            lane = Lane(lane_type=LaneType.ROAD, speed=speed, direction=direction)
+            density = 0.3 + (level - 1) * 0.05
+            self._spawn_road_objects(lane, density)
+            lanes.append(lane)
+
+        # --- Lane 6: SAFE ---
+        lanes.append(Lane(lane_type=LaneType.SAFE, speed=0.0, direction=1))
+
+        # --- Lanes 7–11: RIVER ---
+        river_configs = [
+            (2.0 * speed_scale, 1),
+            (2.5 * speed_scale, -1),
+            (1.5 * speed_scale, 1),
+            (3.0 * speed_scale, -1),
+            (2.0 * speed_scale, 1),
+        ]
+        for speed, direction in river_configs:
+            lane = Lane(lane_type=LaneType.RIVER, speed=speed, direction=direction)
+            self._spawn_river_objects(lane)
+            lanes.append(lane)
+
+        # --- Lane 12: GOAL ---
+        lanes.append(Lane(lane_type=LaneType.GOAL, speed=0.0, direction=1))
+
+        return lanes
+
+    def _spawn_road_objects(self, lane: Lane, density: float) -> None:
+        """Populate a road lane with cars, trucks, and motorcycles.
+
+        Objects are placed at random x positions across the screen width,
+        spread out to avoid immediate overlap.
+
+        Args:
+            lane: The ROAD lane to populate.
+            density: Float in [0, 1] controlling how many objects to spawn.
+        """
+        x = random.uniform(0, SCREEN_WIDTH)
+        gap = SCREEN_WIDTH / max(1, int(density * 8))
+
+        for _ in range(int(density * 8) + 1):
+            roll = random.random()
+            if roll < 0.5:
+                sprite = random.choice(CAR_SPRITES)
+                color = random.choice([Color.BRIGHT_RED, Color.YELLOW, Color.CYAN])
+            elif roll < 0.75:
+                sprite = random.choice(TRUCK_SPRITES)
+                color = Color.BRIGHT_WHITE
+            else:
+                sprite = random.choice(MOTORCYCLE_SPRITES)
+                color = Color.BRIGHT_MAGENTA
+
+            obj = LaneObject(
+                x=x % SCREEN_WIDTH,
+                width=len(sprite),
+                chars=sprite,
+                color=color,
+            )
+            lane.objects.append(obj)
+            x += gap + random.uniform(2, 6)
+
+    def _spawn_river_objects(self, lane: Lane) -> None:
+        """Populate a river lane with logs and turtle groups.
+
+        Logs are longer platforms; turtle groups are shorter and can dive.
+
+        Args:
+            lane: The RIVER lane to populate.
+        """
+        x = random.uniform(0, SCREEN_WIDTH)
+
+        for _ in range(random.randint(3, 5)):
+            if random.random() < 0.5:
+                # Log: 4–8 chars wide
+                log_len = random.randint(4, 8)
+                obj = LaneObject(
+                    x=x % SCREEN_WIDTH,
+                    width=log_len,
+                    chars=LOG_CHAR * log_len,
+                    color=Color.GREEN,
+                )
+            else:
+                # Turtle group: 2–3 turtles
+                count = random.randint(2, 3)
+                obj = LaneObject(
+                    x=x % SCREEN_WIDTH,
+                    width=count,
+                    chars=TURTLE_CHAR * count,
+                    color=Color.BRIGHT_GREEN,
+                    dive_phase=random.uniform(3.0, 6.0),
+                )
+            lane.objects.append(obj)
+            x += random.uniform(8, 16)
+
+    # ------------------------------------------------------------------
+    # Game loop helpers
+    # ------------------------------------------------------------------
+
+    def update(self, dt: float) -> None:
+        """Advance all scrolling lane objects and tick turtle dive timers.
+
+        Args:
+            dt: Delta time in seconds since the last update.
+        """
+        for lane in self.lanes:
+            if lane.speed == 0.0:
+                continue
+
+            dx = lane.speed * lane.direction * dt
+
+            for obj in lane.objects:
+                obj.x += dx
+
+                # Wrap around: right-scrolling objects exiting right edge
+                if lane.direction == 1:
+                    if obj.x >= SCREEN_WIDTH:
+                        obj.x = -obj.width
+                else:
+                    # Left-scrolling: exit left edge → reappear at right
+                    if obj.x + obj.width <= 0:
+                        obj.x = float(SCREEN_WIDTH)
+
+                # Turtle dive timer
+                if obj.chars.startswith(TURTLE_CHAR) and obj.dive_phase > 0:
+                    obj.dive_timer += dt
+                    if obj.dive_timer >= obj.dive_phase:
+                        obj.dive_timer = 0.0
+                        obj.is_diving = not obj.is_diving
+                        # Swap phase length for the next state
+                        obj.dive_phase = (
+                            random.uniform(1.5, 3.0)
+                            if obj.is_diving
+                            else random.uniform(3.0, 6.0)
+                        )
+
+    def draw(self) -> None:
+        """Render all lanes and their scrolling objects to the terminal buffer.
+
+        Lanes are drawn bottom-to-top. Lane 0 (START) is at the bottom of the
+        playing field; lane 12 (GOAL) is at the top.  A 1-row border and the
+        HUD occupy the remaining rows.
+        """
+        self.renderer.clear_buffer()
+
+        term_height = self.renderer.height
+
+        # Playing field starts just below the top border.
+        # Lanes drawn from index 12 (top) to 0 (bottom).
+        field_top = 1  # row 0 is top border
+
+        # Lane colors by type
+        lane_bg_colors = {
+            LaneType.START: Color.GREEN,
+            LaneType.ROAD: Color.BRIGHT_BLACK,
+            LaneType.SAFE: Color.GREEN,
+            LaneType.RIVER: Color.BLUE,
+            LaneType.GOAL: Color.BRIGHT_GREEN,
+        }
+
+        for lane_idx in range(LANE_COUNT - 1, -1, -1):
+            lane = self.lanes[lane_idx]
+            # Visual row of the top of this lane (lanes render top-to-bottom)
+            visual_lane = LANE_COUNT - 1 - lane_idx
+            row_start = field_top + visual_lane * ROWS_PER_LANE
+
+            if row_start >= term_height - HUD_ROWS - 1:
+                break  # Don't overwrite HUD
+
+            bg_color = lane_bg_colors.get(lane.lane_type, Color.WHITE)
+
+            # Draw lane background (3 rows)
+            bg_char = "~" if lane.lane_type == LaneType.RIVER else " "
+            for row_offset in range(ROWS_PER_LANE):
+                row = row_start + row_offset
+                if row < term_height - HUD_ROWS - 1:
+                    self.renderer.draw_text(0, row, bg_char * SCREEN_WIDTH, bg_color)
+
+            # Draw objects on the middle row of each lane
+            mid_row = row_start + 1
+            if mid_row < term_height - HUD_ROWS - 1:
+                for obj in lane.objects:
+                    x = int(obj.x)
+                    chars = obj.chars
+                    # Submerged turtles show as water
+                    if obj.is_diving:
+                        chars = "~" * obj.width
+                        color = Color.BLUE
+                    else:
+                        color = obj.color
+
+                    for i, ch in enumerate(chars):
+                        draw_x = x + i
+                        if 0 <= draw_x < SCREEN_WIDTH:
+                            self.renderer.set_pixel(draw_x, mid_row, ch, color)
+
+        # Top border
+        self.renderer.draw_text(0, 0, "─" * SCREEN_WIDTH, Color.BRIGHT_WHITE)
+
+        # HUD rows at the bottom
+        hud_y = term_height - HUD_ROWS
+        self.renderer.draw_text(0, hud_y, "─" * SCREEN_WIDTH, Color.BRIGHT_WHITE)
+        self.renderer.draw_text(
+            2, hud_y + 1,
+            "CLAUGGER  |  Arrows/WASD: Move  |  Q/ESC: Quit",
+            Color.BRIGHT_YELLOW,
+        )
+
+        self.renderer.render()
+
+    # ------------------------------------------------------------------
+    # Terminal size check
+    # ------------------------------------------------------------------
+
+    def _check_terminal_size(self) -> bool:
+        """Return True if the terminal meets the minimum dimensions.
+
+        Returns:
+            True when the terminal is large enough; False otherwise.
+        """
+        return (
+            self.renderer.height >= MIN_TERM_HEIGHT
+            and self.renderer.width >= MIN_TERM_WIDTH
+        )
+
+    def _wait_for_resize(self) -> bool:
+        """Display a resize prompt and wait until dimensions are met or the
+        user quits.
+
+        Returns:
+            True when the terminal is large enough; False if the user quit.
+        """
+        while True:
+            self.renderer.clear_buffer()
+            msg = f"Please resize your terminal to at least {MIN_TERM_WIDTH}x{MIN_TERM_HEIGHT}"
+            cx = max(0, (self.renderer.width - len(msg)) // 2)
+            cy = self.renderer.height // 2
+            self.renderer.draw_text(cx, cy, msg, Color.BRIGHT_YELLOW)
+            self.renderer.render()
+
+            # Re-query dimensions on each check (blessed updates term.width/height)
+            self.renderer.width = self.renderer.term.width
+            self.renderer.height = self.renderer.term.height
+
+            if self._check_terminal_size():
+                return True
+
+            input_type = self.input_handler.get_input(timeout=0.5)
+            if input_type in (InputType.BACK, InputType.QUIT):
+                return False
+
+    # ------------------------------------------------------------------
+    # Main loop
+    # ------------------------------------------------------------------
+
+    def run(self) -> None:
+        """Enter fullscreen and run the game loop until the user quits."""
+        self.renderer.enter_fullscreen()
+        try:
+            # Check terminal dimensions before starting
+            if not self._check_terminal_size():
+                if not self._wait_for_resize():
+                    return
+
+            self.last_time = time.time()
+            running = True
+
+            while running:
+                current_time = time.time()
+                dt = current_time - self.last_time
+                self.last_time = current_time
+                dt = min(dt, 0.1)  # Cap to avoid spiral of death
+
+                input_type = self.input_handler.get_input(timeout=0.001)
+                if input_type in (InputType.BACK, InputType.QUIT):
+                    running = False
+
+                self.update(dt)
+                self.draw()
+                time.sleep(0.033)  # ~30 FPS
+
+        finally:
+            self.renderer.exit_fullscreen()
+            self.input_handler.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def run_claugger() -> None:
+    """Launch the Claugger game.
+
+    Example:
+        >>> run_claugger()
+    """
+    game = Claugger()
+    game.run()
+
+
+if __name__ == "__main__":
+    run_claugger()

--- a/atari_style/demos/games/claugger.py
+++ b/atari_style/demos/games/claugger.py
@@ -62,6 +62,15 @@ MOTORCYCLE_SPRITES: List[str] = [
 LOG_CHAR = "="
 TURTLE_CHAR = "@"
 
+DEATH_MESSAGES = [
+    "Fowl play!",
+    "Chicken tender!",
+    "Poultry in motion... denied!",
+    "That's not how you cross the road!",
+    "Hen-ded!",
+    "Clucked out!",
+]
+
 # ---------------------------------------------------------------------------
 # Lane type enum
 # ---------------------------------------------------------------------------
@@ -135,6 +144,14 @@ class Claugger:
     this skeleton provides the world the chicken will inhabit.
     """
 
+    # Game state constants
+    STATE_TITLE = 0
+    STATE_PLAYING = 1
+    STATE_DYING = 2
+    STATE_GAME_OVER = 3
+    STATE_LEVEL_COMPLETE = 4
+    STATE_READY = 5
+
     def __init__(self) -> None:
         self.renderer = Renderer()
         self.input_handler = InputHandler()
@@ -142,12 +159,20 @@ class Claugger:
         self.last_time: float = time.time()
         self.running: bool = True
 
+        # Game state
+        self.state: int = Claugger.STATE_PLAYING
+
         # Chicken state
         self.chicken_x: int = (SCREEN_WIDTH - CHICKEN_WIDTH) // 2
         self.chicken_lane: int = 0
         self.chicken_facing: str = "up"
         self.chicken_frame: int = 0
         self.chicken_hop_timer: float = 0.0
+
+        # Death animation state
+        self.death_type: str = ""
+        self.death_timer: float = 0.0
+        self.death_message: str = ""
 
     # ------------------------------------------------------------------
     # Lane construction
@@ -321,15 +346,150 @@ class Claugger:
             self.chicken_hop_timer = 0.1
 
     # ------------------------------------------------------------------
-    # Game loop helpers
+    # Collision detection
     # ------------------------------------------------------------------
 
-    def update(self, dt: float) -> None:
-        """Advance all scrolling lane objects and tick turtle dive timers.
+    def check_collisions(self) -> None:
+        """Check for collisions between the chicken and lane objects.
+
+        Road lanes: any bounding-box overlap with a vehicle → STATE_DYING (squash).
+        River lanes: chicken must overlap a non-diving object; if not → STATE_DYING
+        (drown). Overlapping a diving turtle also → STATE_DYING (drown).
+        Safe, Start, and Goal lanes have no hazard.
+        """
+        if self.state != Claugger.STATE_PLAYING:
+            return
+
+        lane = self.lanes[self.chicken_lane]
+        chicken_left = self.chicken_x
+        chicken_right = self.chicken_x + CHICKEN_WIDTH
+
+        if lane.lane_type == LaneType.ROAD:
+            for obj in lane.objects:
+                obj_left = obj.x
+                obj_right = obj.x + obj.width
+                # Bounding box overlap: intervals overlap when left < other_right and right > other_left
+                if chicken_left < obj_right and chicken_right > obj_left:
+                    self.state = Claugger.STATE_DYING
+                    self.death_type = "squash"
+                    self.death_timer = 1.5
+                    self.death_message = random.choice(DEATH_MESSAGES)
+                    return
+
+        elif lane.lane_type == LaneType.RIVER:
+            # Check each object for overlap
+            for obj in lane.objects:
+                obj_left = obj.x
+                obj_right = obj.x + obj.width
+                if chicken_left < obj_right and chicken_right > obj_left:
+                    # Overlapping an object — check if it's a diving turtle
+                    if obj.is_diving:
+                        self.state = Claugger.STATE_DYING
+                        self.death_type = "drown"
+                        self.death_timer = 1.5
+                        self.death_message = random.choice(DEATH_MESSAGES)
+                    # Otherwise safe — found a valid platform
+                    return
+            # No overlap with any object → drown
+            self.state = Claugger.STATE_DYING
+            self.death_type = "drown"
+            self.death_timer = 1.5
+            self.death_message = random.choice(DEATH_MESSAGES)
+
+    # ------------------------------------------------------------------
+    # River riding
+    # ------------------------------------------------------------------
+
+    def update_river_riding(self, dt: float) -> None:
+        """Shift the chicken along with any log or non-diving turtle it rides.
+
+        Called only during STATE_PLAYING. If the chicken is in a RIVER lane
+        and overlaps a non-diving object, the chicken is moved by the lane's
+        scroll velocity for this frame.
 
         Args:
             dt: Delta time in seconds since the last update.
         """
+        if self.state != Claugger.STATE_PLAYING:
+            return
+
+        lane = self.lanes[self.chicken_lane]
+        if lane.lane_type != LaneType.RIVER:
+            return
+
+        chicken_left = self.chicken_x
+        chicken_right = self.chicken_x + CHICKEN_WIDTH
+
+        for obj in lane.objects:
+            obj_left = obj.x
+            obj_right = obj.x + obj.width
+            if chicken_left < obj_right and chicken_right > obj_left and not obj.is_diving:
+                drift = lane.speed * lane.direction * dt
+                self.chicken_x += drift
+                # Clamp to screen bounds
+                self.chicken_x = max(0, min(SCREEN_WIDTH - CHICKEN_WIDTH, self.chicken_x))
+                return
+
+    # ------------------------------------------------------------------
+    # Turtle dive updates
+    # ------------------------------------------------------------------
+
+    def update_turtle_dives(self, dt: float) -> None:
+        """Advance turtle dive timers and toggle diving state when phases expire.
+
+        Each turtle object toggles between surfaced (4 s default) and diving
+        (2 s default) phases. The phase durations are fixed so tests can
+        predict transitions reliably.
+
+        Args:
+            dt: Delta time in seconds since the last update.
+        """
+        for lane in self.lanes:
+            if lane.lane_type != LaneType.RIVER:
+                continue
+            for obj in lane.objects:
+                if TURTLE_CHAR not in obj.chars:
+                    continue
+                if obj.dive_phase <= 0:
+                    continue
+                obj.dive_timer += dt
+                if obj.dive_timer >= obj.dive_phase:
+                    obj.is_diving = not obj.is_diving
+                    obj.dive_timer = 0.0
+                    obj.dive_phase = 2.0 if obj.is_diving else 4.0
+
+    # ------------------------------------------------------------------
+    # Game loop helpers
+    # ------------------------------------------------------------------
+
+    def _respawn_chicken(self) -> None:
+        """Reset the chicken to the starting position."""
+        self.chicken_x = (SCREEN_WIDTH - CHICKEN_WIDTH) // 2
+        self.chicken_lane = 0
+        self.chicken_facing = "up"
+
+    def update(self, dt: float) -> None:
+        """Advance game state for one frame.
+
+        During STATE_PLAYING: scrolls lane objects, runs turtle dive timers,
+        river riding, and collision detection.
+        During STATE_DYING: counts down the death animation timer and
+        transitions back to STATE_PLAYING (respawn) when it expires.
+
+        Args:
+            dt: Delta time in seconds since the last update.
+        """
+        if self.state == Claugger.STATE_DYING:
+            self.death_timer -= dt
+            if self.death_timer <= 0.0:
+                self._respawn_chicken()
+                self.state = Claugger.STATE_PLAYING
+            return
+
+        if self.state != Claugger.STATE_PLAYING:
+            return
+
+        # Scroll lane objects
         for lane in self.lanes:
             if lane.speed == 0.0:
                 continue
@@ -348,18 +508,10 @@ class Claugger:
                     if obj.x + obj.width <= 0:
                         obj.x = float(SCREEN_WIDTH)
 
-                # Turtle dive timer
-                if obj.chars.startswith(TURTLE_CHAR) and obj.dive_phase > 0:
-                    obj.dive_timer += dt
-                    if obj.dive_timer >= obj.dive_phase:
-                        obj.dive_timer = 0.0
-                        obj.is_diving = not obj.is_diving
-                        # Swap phase length for the next state
-                        obj.dive_phase = (
-                            random.uniform(1.5, 3.0)
-                            if obj.is_diving
-                            else random.uniform(3.0, 6.0)
-                        )
+        # Update turtle dives, river riding, then collisions
+        self.update_turtle_dives(dt)
+        self.update_river_riding(dt)
+        self.check_collisions()
 
     def draw(self) -> None:
         """Render all lanes and their scrolling objects to the terminal buffer.
@@ -425,19 +577,34 @@ class Claugger:
         self.renderer.draw_text(0, 0, "─" * SCREEN_WIDTH, Color.BRIGHT_WHITE)
 
         # --- Chicken sprite ---
-        sprite_rows = CHICKEN_SPRITES.get(self.chicken_facing, CHICKEN_SPRITES["idle"])
-        # Calculate terminal row for the chicken's lane (same formula as lanes above)
         visual_lane = LANE_COUNT - 1 - self.chicken_lane
         lane_row_start = field_top + visual_lane * ROWS_PER_LANE
-        # Center sprite vertically within the 3 rows of the lane (row offset 0 = top row,
-        # 1 = middle row used for the bottom sprite row so both rows fit neatly)
-        sprite_top_row = lane_row_start  # top row of sprite
-        sprite_bot_row = lane_row_start + 1  # bottom row of sprite
-        chicken_color = Color.BRIGHT_YELLOW
-        if sprite_top_row < term_height - HUD_ROWS - 1:
-            self.renderer.draw_text(self.chicken_x, sprite_top_row, sprite_rows[0], chicken_color)
-        if sprite_bot_row < term_height - HUD_ROWS - 1:
-            self.renderer.draw_text(self.chicken_x, sprite_bot_row, sprite_rows[1], chicken_color)
+        sprite_top_row = lane_row_start
+        sprite_bot_row = lane_row_start + 1
+
+        if self.state == Claugger.STATE_DYING:
+            # Death animation: show a flattened/splashed sprite
+            if self.death_type == "squash":
+                death_sprite = ["%X%", "~~~"]
+            else:
+                death_sprite = ["~o~", "~~~"]
+            death_color = Color.BRIGHT_RED if self.death_type == "squash" else Color.CYAN
+            if sprite_top_row < term_height - HUD_ROWS - 1:
+                self.renderer.draw_text(int(self.chicken_x), sprite_top_row, death_sprite[0], death_color)
+            if sprite_bot_row < term_height - HUD_ROWS - 1:
+                self.renderer.draw_text(int(self.chicken_x), sprite_bot_row, death_sprite[1], death_color)
+            # Centered death message
+            if self.death_message:
+                msg_x = max(0, (SCREEN_WIDTH - len(self.death_message)) // 2)
+                msg_y = term_height // 2
+                self.renderer.draw_text(msg_x, msg_y, self.death_message, Color.BRIGHT_YELLOW)
+        else:
+            sprite_rows = CHICKEN_SPRITES.get(self.chicken_facing, CHICKEN_SPRITES["idle"])
+            chicken_color = Color.BRIGHT_YELLOW
+            if sprite_top_row < term_height - HUD_ROWS - 1:
+                self.renderer.draw_text(int(self.chicken_x), sprite_top_row, sprite_rows[0], chicken_color)
+            if sprite_bot_row < term_height - HUD_ROWS - 1:
+                self.renderer.draw_text(int(self.chicken_x), sprite_bot_row, sprite_rows[1], chicken_color)
 
         # HUD rows at the bottom
         hud_y = term_height - HUD_ROWS

--- a/atari_style/demos/visualizers/__init__.py
+++ b/atari_style/demos/visualizers/__init__.py
@@ -8,7 +8,10 @@ from .flux_control_patterns import run_pattern_flux
 from .flux_control_rhythm import run_rhythm_flux
 from .flux_control_zen import run_flux_zen
 from .flux_control_explorer import run_flux_explorer
-from .gl_mandelbrot import run_gl_mandelbrot
+try:
+    from .gl_mandelbrot import run_gl_mandelbrot
+except ImportError:
+    run_gl_mandelbrot = None  # type: ignore[assignment]
 
 __all__ = [
     'run_screensaver',

--- a/atari_style/main.py
+++ b/atari_style/main.py
@@ -18,7 +18,7 @@ def _build_registry() -> ContentRegistry:
     Content unique to atari_style/ (flux control variants, tools) stays as
     register_callable() since those directories lack metadata.json.
     """
-    reg = ContentRegistry(expected_minimum=17)
+    reg = ContentRegistry(expected_minimum=18)
 
     # --- Games: registered with string-based lazy resolution ---
     # These use run_module/run_function_name strings so no eager import happens.
@@ -35,6 +35,9 @@ def _build_registry() -> ContentRegistry:
          "atari_style.demos.games.grandprix", "run_grandprix"),
         ("breakout", "Breakout", "Paddle and ball physics game",
          "atari_style.demos.games.breakout", "run_breakout"),
+        ("claugger", "Claugger",
+         "Why did the chicken cross the road? A Frogger tribute.",
+         "atari_style.demos.games.claugger", "run_claugger"),
     ]:
         reg.register_metadata(ContentMetadata(
             id=game_id, title=title, category=ContentCategory.GAME,

--- a/docs/blog/2026-03-19-claugger-terminal-arcade.md
+++ b/docs/blog/2026-03-19-claugger-terminal-arcade.md
@@ -1,0 +1,67 @@
+---
+title: "Why Did the Chicken Cross the Terminal? Building Arcade Games Where Nobody Expected Them"
+date: 2026-03-19
+description: "A manifesto for terminal gaming and a walkthrough of building Claugger, a Frogger clone starring an ASCII chicken"
+tags: ["python", "terminal", "gamedev", "ascii", "atari-style"]
+author: "jcaldwell"
+showToc: true
+TocOpen: true
+---
+
+## Cold Open
+
+*~200 words planned*
+
+- Reader boots terminal, runs `python run.py`, suddenly playing Frogger with a chicken
+- No X11. No Electron. Just blessed and a dream
+- ASCII chicken dodges oncoming traffic, crosses river, lays eggs — pure arcade nostalgia in 80 columns
+
+## The Thesis: Terminals as Canvas
+
+*~400 words planned*
+
+- "The terminal is a canvas, not a cage" — foundational principle
+- History: nethack, demoscene, ASCII art traditions prove constraints breed creativity
+- Why terminals matter: universally available, scriptable, SSH-friendly, retro appeal
+- Terminal gaming breaks the PC-centric assumption; brings back wonder to the command line
+
+## The Toolkit
+
+*~500 words planned*
+
+- `blessed` library: abstraction over terminfo, cross-platform terminal magic
+- `pygame` for joystick/input abstraction (joystick detection, deadzone handling, multi-platform)
+- `Renderer` abstraction: double buffering for flicker-free animation, color system, aspect ratio correction
+- `InputHandler` unification: keyboard + joystick → single event stream
+- Architecture references: modular design, clear separation of concerns
+
+## Building Claugger
+
+*~1200 words planned*
+
+- Chicken sprite + walk cycle animation (4-frame sprite using ASCII characters)
+- Lane system: cars, logs, water — collision detection when poultry meets Pontiac
+- Movement: 4-directional grid-based stepping with animation
+- Bonus mechanic: egg-laying on successful river crossing (points + visual feedback)
+- HUD with puns: "Lives Remaining", "Eggs Laid", score, level counter
+- Integration into menu via `ContentRegistry` or game launcher
+- Code walk-through: the Claugger class structure, game loop, collision system
+
+## The Bigger Picture
+
+*~400 words planned*
+
+- Full project: Pac-Man, Galaga, Grand Prix, Breakout, creative tools (ASCII Painter), visual demos (Starfield, Platonic Solids)
+- Modular architecture: each game is self-contained, reusable core components
+- Shared utilities: font loading, sprite management, collision detection
+- Contributor guide: how to add a new game (template, required methods, testing)
+- Roadmap: future games, community contributions, cross-platform improvements
+
+## Closing
+
+*~200 words planned*
+
+- Chickens have always belonged in terminals; we just forgot for 30 years
+- Terminal gaming reclaims a lost frontier: no GPU required, pure algorithmic creativity
+- Open source arcade revival: invite readers to contribute, fork, remix
+- Final thought: the best graphics are the ones the player draws in their own mind

--- a/docs/blog/2026-03-19-claugger-terminal-arcade.md
+++ b/docs/blog/2026-03-19-claugger-terminal-arcade.md
@@ -10,58 +10,279 @@ TocOpen: true
 
 ## Cold Open
 
-*~200 words planned*
+It's a Tuesday evening. You open a terminal. Not because you need to deploy anything or fix a broken build or SSH into a production box that's been paging you for an hour. You open it because you want to *play*.
 
-- Reader boots terminal, runs `python run.py`, suddenly playing Frogger with a chicken
-- No X11. No Electron. Just blessed and a dream
-- ASCII chicken dodges oncoming traffic, crosses river, lays eggs — pure arcade nostalgia in 80 columns
+```bash
+python run.py
+```
+
+A menu appears. You scroll past Pac-Man, past Galaga, past something called "Platonic Solids," and land on a new entry: **Claugger**. You press Enter.
+
+Suddenly you're navigating a three-character-wide chicken across five lanes of oncoming ASCII traffic. Sedans (`[==]`) drift left. Trucks (`[####]`) barrel right. You dodge a motorcycle (`()>`), hop onto the median, and face the river section --- logs made of equals signs, turtle groups that periodically dive beneath the surface. You ride a log to safety, hop to the goal row, and the HUD informs you: "EGG-cellent! Level 1 complete!"
+
+No X11 server. No GPU. No Electron. No 400MB runtime dependency to render a rectangle. Just `blessed`, `pygame`, and approximately 900 lines of Python doing things the terminal specification never explicitly forbade.
+
+This is atari-style, and the chicken is just the beginning.
 
 ## The Thesis: Terminals as Canvas
 
-*~400 words planned*
+The first line of the [atari-style philosophy](https://github.com/jcaldwell-labs/atari-style/blob/master/PHILOSOPHY.md) reads: *"The terminal is a canvas, not a cage."* That single sentence carries about thirty years of accumulated frustration with the way our industry talks about text mode.
 
-- "The terminal is a canvas, not a cage" — foundational principle
-- History: nethack, demoscene, ASCII art traditions prove constraints breed creativity
-- Why terminals matter: universally available, scriptable, SSH-friendly, retro appeal
-- Terminal gaming breaks the PC-centric assumption; brings back wonder to the command line
+We've always known this, really. NetHack shipped in 1987 and generated more hours of genuine human engagement than most AAA titles. The demoscene crammed entire universes into 80x25. ASCII art predates the web. The medium isn't a limitation any more than the sonnet form limited Shakespeare or the 12-bar blues limited Muddy Waters. It's a *format*. And formats breed creativity precisely because they say "no" to almost everything.
+
+Terminal constraints --- character cells, limited color palettes, text streams --- aren't bugs to work around. They're the reason this is interesting. An 80-column display forces you to think about density and rhythm in ways that a 4K canvas simply doesn't. When you can't anti-alias, you learn to pick the right Unicode glyph. When you have sixteen colors, each one matters.
+
+The atari-style project exists to prove this thesis by building things nobody asked for: a full Pac-Man with four ghost AI personalities, a first-person 3D racing game rendered in text, a parametric screen saver with more tunable parameters than most synthesizers, and now a Frogger tribute starring a chicken. The terminal didn't ask for any of this. But then, the terminal never said no either.
+
+There's a passage in the philosophy document that I keep coming back to: *"Play is serious work. Games, toys, and playful exploration are valid ways to learn and create. The line between 'productive' and 'playful' is artificial."* If you've ever felt guilty for spending an evening making something useless and beautiful in a terminal, consider this your permission slip.
 
 ## The Toolkit
 
-*~500 words planned*
+Before we build a chicken, we need a stage. atari-style runs on two Python libraries and a thin abstraction layer that makes them behave.
 
-- `blessed` library: abstraction over terminfo, cross-platform terminal magic
-- `pygame` for joystick/input abstraction (joystick detection, deadzone handling, multi-platform)
-- `Renderer` abstraction: double buffering for flicker-free animation, color system, aspect ratio correction
-- `InputHandler` unification: keyboard + joystick → single event stream
-- Architecture references: modular design, clear separation of concerns
+**blessed** is the terminal library for people who've met curses and decided life was too short. It wraps terminfo capabilities in a Pythonic API, handles cross-platform terminal detection, and gives you context managers instead of global state. If curses is a manual transmission with a sticky third gear, blessed is an automatic that still lets you downshift when you want to.
+
+**pygame** seems like an odd choice for a terminal project, but we're not using it for rendering --- we're using it for joystick input. pygame's joystick subsystem handles USB device detection, axis deadzones, button state tracking, and hot-plug reconnection. The terminal gets the pixels; pygame gets the sticks.
+
+The **Renderer** class is where these converge. It maintains a double buffer --- two 2D arrays of characters and colors, one for building the next frame and one for what's currently on screen. Every frame, you write to the buffer; when you're done, one `render()` call flushes it:
+
+```python
+class Renderer:
+    """Handles terminal rendering with double buffering."""
+
+    def __init__(self):
+        self.term = Terminal()
+        self.width = self.term.width
+        self.height = self.term.height
+        self.buffer = [[' ' for _ in range(self.width)]
+                       for _ in range(self.height)]
+        self.color_buffer = [[None for _ in range(self.width)]
+                             for _ in range(self.height)]
+
+    def set_pixel(self, x: int, y: int, char: str = '█',
+                  color: Optional[str] = None):
+        if 0 <= x < self.width and 0 <= y < self.height:
+            self.buffer[y][x] = char[0] if char else ' '
+            self.color_buffer[y][x] = color
+```
+
+The API is deliberately simple: `set_pixel()`, `draw_text()`, `draw_box()`, `draw_border()`. No scene graphs, no entity-component systems, no thirty-seven layers of abstraction between you and the character cell. You put a character somewhere. It shows up.
+
+The **InputHandler** unifies keyboard and joystick into a single event stream. Arrow keys, WASD, and joystick axes all collapse into the same `InputType` enum --- `UP`, `DOWN`, `LEFT`, `RIGHT`, `SELECT`, `BACK`. Your game logic never needs to know whether the player is using a keyboard or a $60 arcade stick:
+
+```python
+class InputType(Enum):
+    NONE = 0
+    UP = 1
+    DOWN = 2
+    LEFT = 3
+    RIGHT = 4
+    SELECT = 5
+    BACK = 6
+    QUIT = 7
+```
+
+This is the entire input vocabulary. Seven words and silence. Everything in atari-style speaks this language, from Pac-Man to the ASCII Painter to the joystick test utility. The architecture documentation has more detail at [jcaldwell-labs.github.io/docs/atari-style/architecture/](https://jcaldwell-labs.github.io/docs/atari-style/architecture/).
 
 ## Building Claugger
 
-*~1200 words planned*
+With the toolkit in hand, let's build a game. Claugger is a Frogger tribute --- five lanes of road traffic, a safe median, five lanes of river with logs and diving turtles, and a goal row at the top. The twist: your protagonist is a chicken that occasionally lays eggs.
 
-- Chicken sprite + walk cycle animation (4-frame sprite using ASCII characters)
-- Lane system: cars, logs, water — collision detection when poultry meets Pontiac
-- Movement: 4-directional grid-based stepping with animation
-- Bonus mechanic: egg-laying on successful river crossing (points + visual feedback)
-- HUD with puns: "Lives Remaining", "Eggs Laid", score, level counter
-- Integration into menu via `ContentRegistry` or game launcher
-- Code walk-through: the Claugger class structure, game loop, collision system
+### The Chicken
+
+Every game needs a protagonist, and ours is three characters wide and two rows tall. Five directional sprites, each a pair of strings:
+
+```python
+CHICKEN_SPRITES = {
+    "up":    [">^<", "/|\\"],
+    "down":  ["\\|/", ">v<"],
+    "left":  ["<(^", " )>"],
+    "right": ["^)>", "<( "],
+    "idle":  [">Q<", " ^ "],
+}
+```
+
+There's something deeply satisfying about designing a character in six bytes. The idle sprite --- `>Q<` over ` ^ ` --- manages to look like a chicken staring at you with mild disapproval, which is exactly the expression a chicken would have if you told it to cross a highway. The directional sprites use carets and parentheses to suggest motion. It's not pixel art. It's *glyph* art, and the constraints make every character choice feel consequential.
+
+Movement is grid-based, stepping one lane vertically or one chicken-width horizontally per input:
+
+```python
+def move_chicken(self, dx: int, dy: int) -> None:
+    if dy != 0:
+        new_lane = self.chicken_lane + dy
+        new_lane = max(0, min(LANE_COUNT - 1, new_lane))
+        if new_lane != self.chicken_lane:
+            self.chicken_lane = new_lane
+            if dy > 0 and self.chicken_lane > self.highest_lane_this_life:
+                points = (self.chicken_lane - self.highest_lane_this_life) * 10
+                self.score += points
+                self.highest_lane_this_life = self.chicken_lane
+
+    if dx != 0:
+        new_x = self.chicken_x + dx * CHICKEN_WIDTH
+        new_x = max(0, min(SCREEN_WIDTH - CHICKEN_WIDTH, new_x))
+        self.chicken_x = new_x
+
+    if moved:
+        self.chicken_hop_timer = 0.1
+        self.try_lay_egg()
+```
+
+Notice the scoring: every new highest lane reached awards 10 points. This encourages forward progress and punishes retreating, which is how Frogger has always worked --- the game rewards bravery, not caution. And that `try_lay_egg()` call at the end? We'll get to that.
+
+### The Lane System
+
+The playing field is thirteen lanes stacked vertically: a start row, five road lanes, a safe median, five river lanes, and a goal row. Each lane is a dataclass with a type, speed, direction, and a list of scrolling objects:
+
+```python
+class LaneType(Enum):
+    START = "start"
+    ROAD = "road"
+    SAFE = "safe"
+    RIVER = "river"
+    GOAL = "goal"
+
+@dataclass
+class Lane:
+    lane_type: LaneType
+    speed: float
+    direction: int          # +1 right, -1 left
+    objects: List[LaneObject] = field(default_factory=list)
+```
+
+The `_build_lanes()` method constructs the world with escalating difficulty. Road lanes get faster and denser each level; river objects maintain their rhythm but the speed scaling makes precise timing harder:
+
+```python
+speed_scale = 1.0 + (level - 1) * 0.2
+
+road_configs = [
+    (2.0 * speed_scale, 1),    # lane 1: slow, rightward
+    (3.0 * speed_scale, -1),   # lane 2: medium, leftward
+    (2.5 * speed_scale, 1),    # lane 3: medium, rightward
+    (4.0 * speed_scale, -1),   # lane 4: fast, leftward
+    (3.5 * speed_scale, 1),    # lane 5: fast, rightward
+]
+```
+
+Traffic objects are satisfyingly varied --- sedans (`[==]`), trucks (`[====]`), motorcycles (`()>`) --- each spawned with random spacing and color. The visual density of a busy road lane, with bright red sedans and magenta motorcycles weaving past cyan sports cars, creates a surprisingly readable kind of chaos. You can parse the danger at a glance, which is exactly what good game design demands.
+
+### When Poultry Meets Pontiac
+
+Collision detection is where Claugger earns its keep. Road lanes and river lanes have fundamentally different collision semantics:
+
+```python
+def check_collisions(self) -> None:
+    if self.state != Claugger.STATE_PLAYING:
+        return
+
+    lane = self.lanes[self.chicken_lane]
+    chicken_left = self.chicken_x
+    chicken_right = self.chicken_x + CHICKEN_WIDTH
+
+    if lane.lane_type == LaneType.ROAD:
+        for obj in lane.objects:
+            obj_left = obj.x
+            obj_right = obj.x + obj.width
+            if chicken_left < obj_right and chicken_right > obj_left:
+                self._trigger_death("squash")
+                return
+
+    elif lane.lane_type == LaneType.RIVER:
+        for obj in lane.objects:
+            obj_left = obj.x
+            obj_right = obj.x + obj.width
+            if chicken_left < obj_right and chicken_right > obj_left:
+                if obj.is_diving:
+                    self._trigger_death("drown")
+                return
+        self._trigger_death("drown")
+```
+
+On the road, touching anything kills you. In the river, *not* touching anything kills you --- you must be standing on a log or a surfaced turtle, or you drown. Diving turtles are the cruelest: they look safe, then they submerge, and suddenly there's nothing under your feet. It's the same bounding-box overlap test in both cases, but the boolean logic inverts. Road: overlap is death. River: non-overlap is death. Two lines of code, completely different feel.
+
+And when death comes, it comes with commentary:
+
+```python
+DEATH_MESSAGES = [
+    "Fowl play!",
+    "Chicken tender!",
+    "Poultry in motion... denied!",
+    "That's not how you cross the road!",
+    "Hen-ded!",
+    "Clucked out!",
+]
+```
+
+The game over screen announces "THE ROOST IS COOKED" in bright red. We take our puns seriously here.
+
+### The Egg-Laying Bonus
+
+Claugger's signature mechanic: every hop has a 5% chance of laying an egg. Eggs persist on the field, ride logs in river lanes, and get squashed by passing vehicles on road lanes. Surviving eggs score 200 points each when a level is completed:
+
+```python
+def try_lay_egg(self) -> None:
+    lane = self.lanes[self.chicken_lane]
+    if lane.lane_type in (LaneType.SAFE, LaneType.START, LaneType.GOAL):
+        return
+    if random.random() < 0.05:
+        self.lay_egg()
+```
+
+The `Egg` dataclass tracks position, lane, and an optional attachment to a river object:
+
+```python
+@dataclass
+class Egg:
+    x: float
+    lane: int
+    attached_object: LaneObject = None
+    squashed: bool = False
+    splat_timer: float = 0.0
+```
+
+River eggs ride their platform --- when a log scrolls right, the egg scrolls with it. Road eggs sit in traffic and pray. Every ten eggs laid earns an extra life, announced with the message "EGGS-tra life!" because once you commit to a theme, you commit *all the way*.
+
+There's also a Konami Code easter egg that activates "Golden Rooster" mode --- five seconds of invincibility, announced with "COCKA-DOODLE-CHEAT!" This is the kind of detail that exists purely because making it was more fun than not making it, which, per the philosophy document, is reason enough.
+
+### Adding to the Menu
+
+Integration with the larger atari-style project is handled through the ContentRegistry system. One registration call in `main.py` and Claugger appears in the menu alongside its siblings:
+
+```python
+("claugger", "Claugger",
+ "Why did the chicken cross the road? A Frogger tribute.",
+ "atari_style.demos.games.claugger", "run_claugger"),
+```
+
+The registry handles lazy imports, category grouping, and metadata --- the game module isn't loaded until the player actually selects it. This keeps the menu snappy even as the project grows.
 
 ## The Bigger Picture
 
-*~400 words planned*
+Claugger is the newest entry in a collection that's been growing steadily. The full atari-style roster now includes:
 
-- Full project: Pac-Man, Galaga, Grand Prix, Breakout, creative tools (ASCII Painter), visual demos (Starfield, Platonic Solids)
-- Modular architecture: each game is self-contained, reusable core components
-- Shared utilities: font loading, sprite management, collision detection
-- Contributor guide: how to add a new game (template, required methods, testing)
-- Roadmap: future games, community contributions, cross-platform improvements
+**Five arcade games**: Pac-Man with four distinct ghost AI personalities (Blinky chases, Pinky ambushes, Inky flanks, Clyde panics), Galaga with wave-based formations and dive attacks, Grand Prix with first-person 3D road rendering and eight AI opponents, Breakout with five power-up types and combo scoring, and now Claugger. Each is a self-contained module that shares the same Renderer and InputHandler infrastructure.
+
+**Creative tools**: The ASCII Painter provides a full drawing program with six tools (freehand, line, rectangle, circle, flood fill, erase), four character palettes including box-drawing and block elements, 14 colors, undo/redo, and file export. It's the kind of tool that makes you realize how much artistic range a character cell actually has.
+
+**Visual demos**: The Starfield simulation layers parallax depth, nebula clouds, warp tunnel effects, and hyperspace jumps into a surprisingly immersive space flight experience. Platonic Solids renders all five regular polyhedra with real-time rotation, wireframe edges, and perspective projection --- a geometry textbook that moves. The Screen Saver provides eight parametric animations with four adjustable parameters each, creating a vast space of visual states to explore.
+
+The architecture is modular by design. Every game follows the same pattern: initialize a Renderer and InputHandler, implement `update()` and `draw()` methods, run a frame loop. The [API reference](https://jcaldwell-labs.github.io/docs/atari-style/api-reference/) documents the shared interfaces. The [tutorial](https://jcaldwell-labs.github.io/docs/atari-style/tutorial/) walks through building a new game from scratch. The barrier to contribution is deliberately low --- if you can write a Python class with an `update()` method, you can add a game.
 
 ## Closing
 
-*~200 words planned*
+There's an old joke that asks why the chicken crossed the road. The answer, supposedly, is "to get to the other side." It's an anti-joke --- the humor is in the absence of humor.
 
-- Chickens have always belonged in terminals; we just forgot for 30 years
-- Terminal gaming reclaims a lost frontier: no GPU required, pure algorithmic creativity
-- Open source arcade revival: invite readers to contribute, fork, remix
-- Final thought: the best graphics are the ones the player draws in their own mind
+Claugger inverts that. The chicken crosses the road because crossing the road is *fun*. Because dodging ASCII traffic in a terminal is inherently, irreducibly delightful in a way that no amount of polygon count or shader complexity can replicate. Because sometimes the best graphics are three characters wide and two rows tall, and they look like this: `>Q<`.
+
+The terminal has been a creative medium for longer than most of us have been alive. We just forgot for a while, distracted by the entirely reasonable but ultimately incomplete idea that more pixels meant more possibilities. They don't. More constraints mean more possibilities --- or at least, more *interesting* ones.
+
+atari-style is open source, MIT-licensed, and waiting for you at [github.com/jcaldwell-labs/atari-style](https://github.com/jcaldwell-labs/atari-style). Clone it, play it, break it, add to it. The [contributing guide](https://jcaldwell-labs.github.io/docs/atari-style/contributing/) explains how to add a new game. The chicken is watching. It looks mildly disapproving. That's just how chickens look.
+
+```bash
+git clone https://github.com/jcaldwell-labs/atari-style.git
+cd atari-style
+pip install -r requirements.txt
+python run.py
+```
+
+See you on the other side.

--- a/docs/site/atari-style/api-reference.md
+++ b/docs/site/atari-style/api-reference.md
@@ -1,0 +1,526 @@
+---
+title: "API Reference"
+weight: 3
+---
+
+# API Reference
+
+This page documents all public APIs in the core modules. Import paths are absolute from the package root.
+
+---
+
+## Renderer
+
+```python
+from atari_style.core.renderer import Renderer, Color, Palette
+```
+
+### `Renderer`
+
+Handles terminal rendering with double buffering. All drawing operations write to an in-memory buffer; call `render()` to flush to the terminal.
+
+#### Constructor
+
+```python
+renderer = Renderer()
+```
+
+Initializes the terminal connection and creates empty character and color buffers sized to the current terminal dimensions.
+
+**Attributes after construction**:
+- `renderer.width: int` — terminal width in columns
+- `renderer.height: int` — terminal height in rows
+- `renderer.term` — the underlying `blessed.Terminal` instance
+
+---
+
+#### `clear_buffer() -> None`
+
+Reset all characters and colors in the buffer to empty. Call at the start of each frame before drawing.
+
+```python
+renderer.clear_buffer()
+```
+
+---
+
+#### `set_pixel(x: int, y: int, char: str = '█', color: Optional[str] = None) -> None`
+
+Write a single character at column `x`, row `y`. Out-of-bounds coordinates are silently ignored.
+
+```python
+renderer.set_pixel(10, 5, '@', Color.BRIGHT_GREEN)
+renderer.set_pixel(0, 0, '.')          # no color — uses terminal default
+```
+
+**Parameters**:
+- `x` — column (0-indexed, left to right)
+- `y` — row (0-indexed, top to bottom)
+- `char` — character to draw; only the first character of the string is used
+- `color` — color name string, or `None` for terminal default
+
+---
+
+#### `draw_text(x: int, y: int, text: str, color: Optional[str] = None) -> None`
+
+Draw a string of characters starting at `(x, y)`. Characters that fall outside the buffer bounds are silently ignored.
+
+```python
+renderer.draw_text(2, 1, "SCORE: 1000", Color.YELLOW)
+```
+
+**Parameters**:
+- `x` — starting column
+- `y` — row
+- `text` — string to render
+- `color` — color name string, or `None`
+
+---
+
+#### `draw_box(x: int, y: int, width: int, height: int, char: str = '█', color: Optional[str] = None) -> None`
+
+Fill a rectangular region with `char`.
+
+```python
+renderer.draw_box(5, 5, 10, 3, '░', Color.BLUE)
+```
+
+**Parameters**:
+- `x`, `y` — top-left corner
+- `width`, `height` — dimensions in characters
+- `char` — fill character
+- `color` — color name string, or `None`
+
+---
+
+#### `draw_border(x: int, y: int, width: int, height: int, color: Optional[str] = None) -> None`
+
+Draw a hollow rectangle using box-drawing characters. Uses `─`, `│`, `┌`, `┐`, `└`, `┘`.
+
+```python
+renderer.draw_border(0, 0, renderer.width, renderer.height, Color.CYAN)
+```
+
+**Parameters**:
+- `x`, `y` — top-left corner
+- `width`, `height` — outer dimensions
+- `color` — color name string, or `None`
+
+---
+
+#### `render() -> None`
+
+Flush the current buffer to the terminal. Walks the buffer arrays and emits terminal cursor positioning and color escape sequences. Call once per frame after all drawing is complete.
+
+```python
+renderer.render()
+```
+
+---
+
+#### `enter_fullscreen() -> None`
+
+Switch the terminal to fullscreen (alternate screen) mode and hide the cursor. Call before the game loop starts.
+
+```python
+renderer.enter_fullscreen()
+```
+
+---
+
+#### `exit_fullscreen() -> None`
+
+Restore the terminal to normal mode and show the cursor. Always call in a `finally` block to ensure the terminal is not left in fullscreen state if the program crashes.
+
+```python
+try:
+    renderer.enter_fullscreen()
+    # game loop
+finally:
+    renderer.exit_fullscreen()
+```
+
+---
+
+#### `clear_screen() -> None`
+
+Clear the terminal display and move the cursor to the home position. Distinct from `clear_buffer()` — this writes directly to the terminal rather than the buffer.
+
+```python
+renderer.clear_screen()
+```
+
+---
+
+#### `save_screenshot(path: str) -> bool`
+
+Export the current buffer as a PNG image. Requires `Pillow` to be installed.
+
+Renders each buffered character using a monospace font into an RGB image with a dark background (Dracula theme: `#1e1e2e`). Falls back to PIL's default bitmap font if no TrueType monospace fonts are found on the system.
+
+```python
+success = renderer.save_screenshot("/tmp/screenshot.png")
+if not success:
+    print("Pillow not installed")
+```
+
+**Parameters**:
+- `path` — output file path; parent directory is created if it does not exist
+
+**Returns**: `True` if the PNG was written successfully, `False` if Pillow is not installed.
+
+**Color support**: Named colors from `Color` constants are mapped to RGB values in the output image.
+
+---
+
+### `Color`
+
+String constants for terminal colors. Pass these to any `color` parameter.
+
+**Standard colors**:
+
+| Constant | Value | Constant | Value |
+|---|---|---|---|
+| `Color.BLACK` | `'black'` | `Color.RED` | `'red'` |
+| `Color.GREEN` | `'green'` | `Color.BLUE` | `'blue'` |
+| `Color.YELLOW` | `'yellow'` | `Color.MAGENTA` | `'magenta'` |
+| `Color.CYAN` | `'cyan'` | `Color.WHITE` | `'white'` |
+
+**Bright colors**:
+
+| Constant | Value | Constant | Value |
+|---|---|---|---|
+| `Color.BRIGHT_BLACK` | `'bright_black'` | `Color.BRIGHT_RED` | `'bright_red'` |
+| `Color.BRIGHT_GREEN` | `'bright_green'` | `Color.BRIGHT_BLUE` | `'bright_blue'` |
+| `Color.BRIGHT_YELLOW` | `'bright_yellow'` | `Color.BRIGHT_MAGENTA` | `'bright_magenta'` |
+| `Color.BRIGHT_CYAN` | `'bright_cyan'` | `Color.BRIGHT_WHITE` | `'bright_white'` |
+
+**Alias**:
+- `Color.GRAY` = `'bright_black'`
+
+---
+
+### `Palette`
+
+Predefined color lists for thematic rendering.
+
+```python
+from atari_style.core.renderer import Palette
+
+colors = Palette.CLASSIC      # list of color strings
+colors = Palette.get('fire')  # by name
+```
+
+**Available palettes**:
+
+| Name | Colors |
+|---|---|
+| `CLASSIC` | bright_cyan, bright_green, bright_yellow, bright_red, bright_magenta, white |
+| `PLASMA` | blue, cyan, green, yellow, red, magenta |
+| `MIDNIGHT` | blue, magenta, bright_magenta, cyan, bright_cyan, white |
+| `FOREST` | green, bright_green, yellow, cyan, bright_white |
+| `FIRE` | red, bright_red, yellow, bright_yellow, white |
+| `OCEAN` | blue, cyan, bright_cyan, green, bright_blue, white |
+| `MONOCHROME` | green, bright_green, bright_white |
+
+#### `Palette.get(name: str) -> list`
+
+Return a palette by name (case-insensitive). Falls back to `CLASSIC` if the name is not recognized.
+
+```python
+colors = Palette.get('midnight')
+```
+
+---
+
+## InputHandler
+
+```python
+from atari_style.core.input_handler import InputHandler, InputType
+```
+
+### `InputType`
+
+Enum of possible input events returned by `get_input()`.
+
+| Member | Value | Triggered by |
+|---|---|---|
+| `InputType.NONE` | 0 | No input within timeout |
+| `InputType.UP` | 1 | Up arrow, W key, joystick axis up |
+| `InputType.DOWN` | 2 | Down arrow, S key, joystick axis down |
+| `InputType.LEFT` | 3 | Left arrow, A key, joystick axis left |
+| `InputType.RIGHT` | 4 | Right arrow, D key, joystick axis right |
+| `InputType.SELECT` | 5 | Enter, Space, joystick button 0 |
+| `InputType.BACK` | 6 | Escape, Q key, joystick button 1 |
+| `InputType.QUIT` | 7 | X key |
+
+### `InputHandler`
+
+```python
+handler = InputHandler()
+```
+
+On construction, initializes pygame, attempts joystick detection, and registers signal handlers for clean shutdown.
+
+---
+
+#### `get_input(timeout: float = 0.1) -> InputType`
+
+Block for up to `timeout` seconds waiting for keyboard input, then check joystick state. Returns the first recognized event, or `InputType.NONE` if nothing was pressed.
+
+```python
+inp = handler.get_input(timeout=0.016)  # ~60 FPS budget
+if inp == InputType.BACK:
+    return False
+```
+
+**Parameters**:
+- `timeout` — seconds to wait for keyboard input; shorter = more responsive but higher CPU usage
+
+**Notes**:
+- Keyboard takes priority over joystick
+- Joystick buttons use edge detection (fires once on press, not while held)
+- Automatically attempts joystick reconnection if disconnected
+
+---
+
+#### `get_joystick_state() -> Tuple[float, float]`
+
+Return the current joystick axis state as `(x, y)`, each normalized to -1.0 to 1.0. A 0.15 deadzone is applied. Returns `(0.0, 0.0)` if no joystick is connected or if a device health check fails.
+
+```python
+x, y = handler.get_joystick_state()
+paddle_x += x * speed * dt
+```
+
+---
+
+#### `get_joystick_buttons() -> dict`
+
+Return a dictionary mapping button index to boolean state for all buttons on the connected joystick. Returns an empty dict if no joystick is connected.
+
+```python
+buttons = handler.get_joystick_buttons()
+if buttons.get(0):   # button 0 held
+    fire()
+```
+
+---
+
+#### `verify_joystick() -> dict`
+
+Return a dictionary describing the connected joystick. Useful for the Joystick Test utility.
+
+```python
+info = handler.verify_joystick()
+# {'connected': True, 'name': 'Xbox Controller', 'axes': 6, 'buttons': 17}
+# {'connected': False, 'name': None, 'axes': 0, 'buttons': 0}
+```
+
+**Returns**:
+- `connected: bool` — whether a joystick is initialized
+- `name: Optional[str]` — joystick name reported by pygame
+- `axes: int` — number of analog axes
+- `buttons: int` — number of buttons
+
+---
+
+#### `cleanup() -> None`
+
+Release joystick resources and remove this instance from the signal handler registry. Always call in a `finally` block.
+
+```python
+try:
+    handler = InputHandler()
+    # game loop
+finally:
+    handler.cleanup()
+```
+
+---
+
+## ContentRegistry
+
+```python
+from atari_style.core.registry import ContentRegistry, ContentMetadata, ContentCategory
+```
+
+### `ContentCategory`
+
+Enum for organizing content in the menu.
+
+| Member | Value |
+|---|---|
+| `ContentCategory.GAME` | `'game'` |
+| `ContentCategory.VISUALIZER` | `'visualizer'` |
+| `ContentCategory.TOOL` | `'tool'` |
+| `ContentCategory.SHADER_DEMO` | `'shader_demo'` |
+
+### `ContentMetadata`
+
+Dataclass describing a piece of registered content.
+
+**Required fields**:
+- `id: str` — unique identifier (kebab-case slug)
+- `title: str` — human-readable display name
+- `category: ContentCategory`
+- `description: str` — short description for menu display
+
+**Launch spec** (at least one required to be launchable):
+- `run_module: Optional[str]` — dotted module path (e.g. `'atari_style.demos.games.pacman'`)
+- `run_function_name: Optional[str]` — function name within the module (e.g. `'run_pacman'`)
+
+**Optional fields**:
+- `backend: RenderingBackend` — default `TERMINAL`
+- `joystick_support: bool` — default `True`
+- `keyboard_support: bool` — default `True`
+- `controls_hint: str` — short controls string
+- `has_intro: bool` — whether content has an intro sequence
+- `is_new: bool` — flag for highlighting in menus
+- `tags: List[str]` — searchable tags
+- `version: str` — default `'1.0'`
+- `author: str`
+- `source_path: Optional[Path]` — filesystem path to source directory
+
+**Property**:
+
+`run_function: Optional[Callable]` — lazily imports and returns the run callable on first access; caches the result. Returns `None` if the module cannot be imported.
+
+### `ContentRegistry`
+
+```python
+registry = ContentRegistry(expected_minimum=18)
+```
+
+**Parameters**:
+- `expected_minimum: int` — if > 0, logs a warning when content count drops below this threshold after scan operations
+
+---
+
+#### `register_metadata(metadata: ContentMetadata) -> None`
+
+Register a `ContentMetadata` instance. Overwrites existing entries with the same `id`.
+
+---
+
+#### `register_callable(id, title, category, description, run_fn, **kwargs) -> ContentMetadata`
+
+Register a directly imported callable. Stores the callable immediately without lazy import.
+
+```python
+from atari_style.demos.games.pacman import run_pacman
+registry.register_callable(
+    id="pacman",
+    title="Pac-Man",
+    category=ContentCategory.GAME,
+    description="Classic maze chase game",
+    run_fn=run_pacman,
+)
+```
+
+---
+
+#### `scan_directory(directory: Path, default_category: ContentCategory = ContentCategory.GAME) -> int`
+
+Scan a directory for subdirectories containing `metadata.json` files. Each valid file is parsed and registered. Returns the number of items registered from this scan.
+
+---
+
+#### `get(id: str) -> Optional[ContentMetadata]`
+
+Look up a single content item by its `id`.
+
+---
+
+#### `get_by_category(category: ContentCategory) -> List[ContentMetadata]`
+
+Return all content items in a given category.
+
+---
+
+#### `get_all() -> List[ContentMetadata]`
+
+Return all registered content.
+
+---
+
+#### `search(query: str) -> List[ContentMetadata]`
+
+Case-insensitive substring search across title, description, and tags.
+
+---
+
+#### `count() -> int`
+
+Total number of registered items.
+
+---
+
+#### `category_counts() -> Dict[ContentCategory, int]`
+
+Count of items per category.
+
+---
+
+## Config
+
+```python
+from atari_style.core.config import Config
+```
+
+### `Config`
+
+Dataclass for persistent application settings. Stored at `~/.atari-style/config.json`.
+
+**Fields**:
+- `char_aspect: float` — terminal character aspect ratio (width/height). Default `0.5`. Valid range: 0.2 to 1.0.
+
+#### `Config.load() -> Config`
+
+Load config from file, or return defaults if the file does not exist or is malformed.
+
+```python
+config = Config.load()
+print(config.char_aspect)  # 0.5
+```
+
+#### `config.save() -> None`
+
+Write current config to `~/.atari-style/config.json`. Creates the directory if needed.
+
+```python
+config = Config.load()
+config.char_aspect = 0.55
+config.save()
+```
+
+---
+
+## load_monospace_font
+
+```python
+from atari_style.utils.fonts import load_monospace_font
+```
+
+#### `load_monospace_font(size: int, preferred_paths: Optional[list[str]] = None) -> ImageFont.FreeTypeFont`
+
+Load a monospace TrueType font for use with Pillow. Tries `preferred_paths` first, then a built-in list of common system font paths for Linux, macOS, and Windows. Falls back to PIL's default bitmap font if nothing is found.
+
+```python
+font = load_monospace_font(16)
+font = load_monospace_font(22, preferred_paths=['/my/custom/mono.ttf'])
+```
+
+**Default search paths** (in order):
+1. `/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf`
+2. `/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf`
+3. `/usr/share/fonts/truetype/ubuntu/UbuntuMono-R.ttf`
+4. `/usr/share/fonts/TTF/DejaVuSansMono.ttf`
+5. `/System/Library/Fonts/Menlo.ttc`
+6. `C:/Windows/Fonts/consola.ttf`
+
+**Parameters**:
+- `size` — font size in points
+- `preferred_paths` — optional list of paths to try before the defaults
+
+**Returns**: A `PIL.ImageFont.FreeTypeFont` instance (or the built-in bitmap font as fallback).

--- a/docs/site/atari-style/architecture.md
+++ b/docs/site/atari-style/architecture.md
@@ -1,0 +1,137 @@
+---
+title: "Architecture Overview"
+weight: 2
+---
+
+# Architecture Overview
+
+atari-style is built around three core modules that every demo uses, plus a registry that handles discovery and launching. Understanding these layers makes it easy to add new content.
+
+## Module Relationships
+
+```
+atari_style/
+├── core/
+│   ├── renderer.py        # Terminal output, double buffering, colors
+│   ├── input_handler.py   # Keyboard + joystick input abstraction
+│   ├── menu.py            # Interactive menu with keyboard/joystick nav
+│   ├── registry.py        # Content discovery, metadata, lazy loading
+│   └── config.py          # Persistent settings (~/.atari-style/config.json)
+├── utils/
+│   └── fonts.py           # Cross-platform monospace font loading
+├── demos/
+│   ├── games/             # Pac-Man, Galaga, Grand Prix, Breakout, Claugger
+│   ├── visualizers/       # Starfield, Screen Saver, Platonic Solids, Flux Control
+│   └── tools/             # ASCII Painter, Canvas Explorer, Joystick Test
+└── main.py                # Entry point — builds registry, constructs menu
+```
+
+All demos import from `..core`. No demo imports from another demo. The core modules have no knowledge of specific games.
+
+## Renderer
+
+`atari_style/core/renderer.py`
+
+The `Renderer` class wraps the `blessed` library and provides double-buffered terminal output. Instead of writing directly to the terminal, all drawing calls write into an in-memory buffer. When `render()` is called, the buffer is flushed to the terminal in one pass, eliminating flicker.
+
+**Double buffering**: The renderer maintains two parallel arrays — `buffer` (characters) and `color_buffer` (color names). Every frame starts with `clear_buffer()`, which resets both arrays to empty. Drawing calls like `set_pixel()` and `draw_text()` populate the arrays. `render()` then walks the arrays and emits terminal escape sequences.
+
+**Color system**: Colors are passed as string names (`'red'`, `'bright_cyan'`, etc.) that map directly to `blessed`'s terminal color attributes. The `Color` class provides named constants (`Color.BRIGHT_CYAN`, `Color.RED`, etc.) to avoid magic strings. The `Palette` class groups colors into thematic sets (CLASSIC, PLASMA, MIDNIGHT, FOREST, FIRE, OCEAN, MONOCHROME).
+
+**Aspect ratio**: Terminal characters are taller than they are wide (roughly 2:1). Demos that draw circles or other shapes that must look correct need to multiply Y coordinates by approximately 0.5 before rendering. This is a rendering guideline, not an automatic correction.
+
+## InputHandler
+
+`atari_style/core/input_handler.py`
+
+`InputHandler` provides a unified interface for keyboard and joystick input. Demos call `get_input()` and receive an `InputType` enum value — they never deal with raw key codes or pygame events directly.
+
+**Keyboard mapping**: Arrow keys and WASD map to directional `InputType` values. Enter and Space map to `SELECT`. Escape and Q map to `BACK`. X maps to `QUIT`.
+
+**Joystick handling**: pygame is used exclusively for joystick input. The handler initializes on construction and attempts reconnection automatically if a joystick is unplugged and replugged (polling approximately every 30 frames). A 0.15 deadzone is applied to analog axes. Digital threshold for axis-to-direction conversion is 0.5.
+
+**Health checks**: The handler performs periodic device health checks (every 1 second) to detect USB device issues before they cause system lockup. If the device becomes unresponsive, the handler marks it unhealthy and stops polling until reconnection succeeds.
+
+**Analog state**: For demos that need raw analog values (paddle position, lateral drift), `get_joystick_state()` returns normalized `(x, y)` floats in the range -1.0 to 1.0 with deadzone already applied.
+
+**Cleanup**: Always call `input_handler.cleanup()` in a `finally` block. This releases USB resources cleanly. Signal handlers (SIGINT, SIGTERM) are registered automatically and call emergency cleanup if the process is killed.
+
+## ContentRegistry
+
+`atari_style/core/registry.py`
+
+The registry is the bridge between the main entry point and the demos. It stores `ContentMetadata` objects that describe each piece of content — its title, category, description, and how to launch it.
+
+**Lazy resolution**: Demos are not imported at startup. Each `ContentMetadata` stores a dotted module path (`run_module`) and function name (`run_function_name`). The `run_function` property uses `importlib.import_module()` on first access and caches the result. This keeps startup fast regardless of how many demos are registered.
+
+**Registration paths**:
+1. `register_metadata()` — direct registration with a `ContentMetadata` instance
+2. `register_callable()` — wraps an already-imported callable; no lazy import needed
+3. `scan_directory()` — scans a directory for subdirectories containing `metadata.json` files
+
+**Auto-discovery**: The `terminal_arcade/games/` directory (if present) is scanned automatically. Games in that directory that share IDs with hardcoded entries (pacman, galaga, etc.) overwrite the hardcoded entries, taking over launch responsibility.
+
+**Categories**: `ContentCategory` has four values: `GAME`, `VISUALIZER`, `TOOL`, `SHADER_DEMO`. The menu displays categories in that order.
+
+## Game Loop Pattern
+
+Every demo follows the same five-method pattern:
+
+```python
+class MyDemo:
+    def __init__(self):
+        self.renderer = Renderer()
+        self.input_handler = InputHandler()
+        # Initialize game state here
+
+    def handle_input(self) -> bool:
+        """Process input. Return False to exit."""
+        inp = self.input_handler.get_input(timeout=0.016)
+        if inp == InputType.BACK:
+            return False
+        # Handle other inputs
+        return True
+
+    def update(self, dt: float):
+        """Advance game state by dt seconds."""
+        pass
+
+    def draw(self):
+        """Draw current state to the renderer buffer."""
+        self.renderer.clear_buffer()
+        # All drawing calls go here
+        self.renderer.render()
+
+    def run(self):
+        self.renderer.enter_fullscreen()
+        try:
+            while True:
+                if not self.handle_input():
+                    break
+                self.update(dt)
+                self.draw()
+                time.sleep(0.033)  # ~30 FPS
+        finally:
+            self.renderer.exit_fullscreen()
+            self.input_handler.cleanup()
+
+
+def run_my_demo():
+    MyDemo().run()
+```
+
+The entry function (`run_my_demo`) is the target registered in the `ContentRegistry`. `main.py` calls this function when the user selects the demo from the menu.
+
+## Menu System
+
+`atari_style/core/menu.py`
+
+The `Menu` class renders a navigable list of `MenuItem` objects. Each `MenuItem` stores a display title, an action callable, and an optional description shown in a detail panel. Navigation uses `InputHandler` internally.
+
+`main.py` builds the registry via `_build_registry()`, converts it to menu items via `_registry_to_menu_items()`, and passes the list to `Menu`. The menu runs until the user selects Exit or presses Q.
+
+## Configuration
+
+`atari_style/core/config.py`
+
+The `Config` dataclass stores persistent settings in `~/.atari-style/config.json`. Currently it holds one field: `char_aspect` (default 0.5), which controls the assumed terminal character aspect ratio for shape calculations. Load with `Config.load()`, modify, then call `.save()`.

--- a/docs/site/atari-style/contributing.md
+++ b/docs/site/atari-style/contributing.md
@@ -1,0 +1,300 @@
+---
+title: "Contributing"
+weight: 5
+---
+
+# Contributing
+
+This guide covers everything you need to contribute to atari-style — dev setup, running tests, code conventions, and how to add a new demo.
+
+## Dev Setup
+
+```bash
+git clone https://github.com/jcaldwell-labs/atari-style.git
+cd atari-style
+
+python3 -m venv venv
+source venv/bin/activate   # Windows: venv\Scripts\activate
+
+# Install in editable mode so changes take effect immediately
+pip install -e .
+
+# Install dev tools
+pip install ruff
+```
+
+## Running Tests
+
+```bash
+python -m unittest discover -s tests -p "test_*.py" -v
+```
+
+Tests live in `tests/`. The naming convention is `test_<module>.py`. Run the full suite before submitting a PR.
+
+**Coverage targets**: Core modules (`renderer`, `input_handler`, `registry`, `config`) require 80% line coverage. New demos need integration tests — not just "runs without error" checks, but assertions that verify observable outcomes.
+
+## Linting
+
+```bash
+ruff check atari_style/ tests/
+```
+
+Fix all reported issues before opening a PR. The CI pipeline runs ruff and will block merges if it fails.
+
+## Code Conventions
+
+These conventions reduce review cycles by making the codebase predictable.
+
+### Constants, Not Magic Numbers
+
+Extract any number with meaning into a named constant at the top of the file:
+
+```python
+# Bad
+if abs(axis_value) > 0.5:
+    ...
+
+# Good
+DIGITAL_THRESHOLD = 0.5
+if abs(axis_value) > DIGITAL_THRESHOLD:
+    ...
+```
+
+### Type Hints on All Public Functions
+
+Every function exposed outside its module must have complete type hints:
+
+```python
+# Bad
+def run_bounce():
+    BouncingBall().run()
+
+# Good
+def run_bounce() -> None:
+    BouncingBall().run()
+```
+
+Private methods (prefixed with `_`) may omit hints if they are straightforward, but public methods and all `__init__` signatures must have them.
+
+### Imports
+
+Only import what you use. Remove unused imports before committing. Use relative imports within the package:
+
+```python
+# Within atari_style/demos/games/mygame.py
+from ...core.renderer import Renderer, Color
+from ...core.input_handler import InputHandler, InputType
+```
+
+Do not import demo modules from other demo modules.
+
+### Docstrings
+
+Public APIs require docstrings with Args and Returns sections:
+
+```python
+def get_input(self, timeout: float = 0.1) -> InputType:
+    """Get input from keyboard or joystick.
+
+    Args:
+        timeout: Seconds to wait for keyboard input before checking joystick.
+
+    Returns:
+        InputType enum value, or InputType.NONE if no input within timeout.
+    """
+```
+
+One-liner docstrings are fine for methods where the purpose is self-evident from the name and signature.
+
+### Security
+
+**HTML output**: Always escape user-supplied data before inserting into HTML strings:
+
+```python
+import html
+safe_name = html.escape(user_filename)
+```
+
+**File paths**: Validate paths before opening files to prevent traversal attacks:
+
+```python
+requested = (base_dir / user_path).resolve()
+if not str(requested).startswith(str(base_dir.resolve())):
+    raise PermissionError("Path outside allowed directory")
+```
+
+**Large files**: Stream rather than loading into memory:
+
+```python
+CHUNK_SIZE = 8192
+with open(path, 'rb') as f:
+    while chunk := f.read(CHUNK_SIZE):
+        output.write(chunk)
+```
+
+## Adding a New Demo
+
+Follow these steps to add a new game, visualizer, or tool.
+
+### 1. Choose a location
+
+| Type | Directory |
+|---|---|
+| Game | `atari_style/demos/games/` |
+| Visual demo | `atari_style/demos/visualizers/` |
+| Tool | `atari_style/demos/tools/` |
+
+### 2. Create your file
+
+```bash
+touch atari_style/demos/games/mygame.py
+```
+
+### 3. Implement the five-method pattern
+
+```python
+"""My game description."""
+
+import time
+from typing import Optional
+
+from ...core.renderer import Renderer, Color
+from ...core.input_handler import InputHandler, InputType
+
+
+MY_CONSTANT = 42  # named constants, not magic numbers
+
+
+class MyGame:
+    """One-line description."""
+
+    def __init__(self) -> None:
+        self.renderer = Renderer()
+        self.input_handler = InputHandler()
+        # initialize state
+
+    def handle_input(self) -> bool:
+        """Process input. Returns False to exit."""
+        inp = self.input_handler.get_input(timeout=0.016)
+        if inp == InputType.BACK:
+            return False
+        return True
+
+    def update(self, dt: float) -> None:
+        """Advance game state by dt seconds."""
+        pass
+
+    def draw(self) -> None:
+        """Render the current frame."""
+        self.renderer.clear_buffer()
+        # drawing calls here
+        self.renderer.render()
+
+    def run(self) -> None:
+        """Main game loop."""
+        self.renderer.enter_fullscreen()
+        last = time.time()
+        try:
+            while True:
+                now = time.time()
+                dt = min(now - last, 0.1)
+                last = now
+                if not self.handle_input():
+                    break
+                self.update(dt)
+                self.draw()
+        finally:
+            self.renderer.exit_fullscreen()
+            self.input_handler.cleanup()
+
+
+def run_my_game() -> None:
+    """Entry point for my game."""
+    MyGame().run()
+```
+
+### 4. Register in main.py
+
+Open `atari_style/main.py`. Find the appropriate registration block and add your entry:
+
+```python
+# For a game:
+for game_id, title, desc, module, func in [
+    # ... existing entries ...
+    ("my-game", "My Game", "Short description of what it does",
+     "atari_style.demos.games.mygame", "run_my_game"),
+]:
+```
+
+For visualizers and tools, add to the corresponding block (`_viz` and `_tools` sections respectively).
+
+### 5. Write a test
+
+Create `tests/test_mygame.py`:
+
+```python
+"""Tests for my game."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class TestMyGame(unittest.TestCase):
+
+    @patch('atari_style.demos.games.mygame.Renderer')
+    @patch('atari_style.demos.games.mygame.InputHandler')
+    def test_initial_state(self, mock_input, mock_renderer):
+        """Game initializes with expected default state."""
+        mock_renderer.return_value.width = 80
+        mock_renderer.return_value.height = 24
+
+        from atari_style.demos.games.mygame import MyGame
+        game = MyGame()
+
+        # Assert concrete outcomes — not just "no exception"
+        self.assertIsNotNone(game.renderer)
+        self.assertIsNotNone(game.input_handler)
+
+    @patch('atari_style.demos.games.mygame.Renderer')
+    @patch('atari_style.demos.games.mygame.InputHandler')
+    def test_handle_input_back_returns_false(self, mock_input, mock_renderer):
+        """BACK input causes handle_input to return False."""
+        from atari_style.core.input_handler import InputType
+        mock_renderer.return_value.width = 80
+        mock_renderer.return_value.height = 24
+        mock_input.return_value.get_input.return_value = InputType.BACK
+
+        from atari_style.demos.games.mygame import MyGame
+        game = MyGame()
+        result = game.handle_input()
+
+        self.assertFalse(result)
+```
+
+### 6. Verify before submitting
+
+Run through this checklist:
+
+- [ ] Actually run the demo end-to-end and observe the behavior
+- [ ] Test at different terminal sizes (small and large)
+- [ ] Test with no joystick connected
+- [ ] Confirm ESC exits cleanly without leaving the terminal in a bad state
+- [ ] Run `ruff check atari_style/ tests/` — zero issues
+- [ ] Run the full test suite — all tests pass
+- [ ] Every test has at least one `assert` that checks a real outcome
+
+## PR Process
+
+1. Fork the repository and create a feature branch: `git checkout -b feat/my-game`
+2. Make your changes following the conventions above
+3. Run lint and tests
+4. Push and open a PR against `master`
+5. The PR description should explain what the demo does and include a screenshot or terminal recording if possible
+
+PR titles follow conventional commits format:
+- `feat: Add my game demo`
+- `fix: Correct ball collision in bounce demo`
+- `refactor: Extract shared physics utility`
+- `docs: Update API reference for Renderer`
+
+Keep PRs focused. A PR that adds a new demo should not also refactor unrelated core code — split those into separate PRs.

--- a/docs/site/atari-style/getting-started.md
+++ b/docs/site/atari-style/getting-started.md
@@ -1,0 +1,120 @@
+---
+title: "Getting Started with atari-style"
+weight: 1
+---
+
+# Getting Started with atari-style
+
+atari-style is a collection of terminal-based arcade games, creative tools, and visual demos inspired by classic Atari aesthetics. Everything runs in your terminal using ASCII and ANSI graphics.
+
+## Prerequisites
+
+- **Python 3.8 or newer** — check with `python3 --version`
+- **A terminal with 256-color support** — most modern terminals qualify (iTerm2, GNOME Terminal, Windows Terminal, Alacritty, kitty)
+- **Terminal size of at least 80x24** — larger is better; many demos benefit from a full-screen terminal
+- **Optional**: A USB gamepad or joystick for full analog control
+
+## Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/jcaldwell-labs/atari-style.git
+cd atari-style
+
+# Create a virtual environment (recommended)
+python3 -m venv venv
+source venv/bin/activate   # Windows: venv\Scripts\activate
+
+# Install dependencies
+pip install -r requirements.txt
+```
+
+Dependencies installed:
+
+| Package | Purpose |
+|---|---|
+| `pygame>=2.5.0` | Joystick input handling |
+| `blessed>=1.20.0` | Terminal rendering and control |
+| `Pillow>=10.0.0` | Screenshot export (optional feature) |
+| `moderngl>=5.8.0` | GPU-accelerated demos |
+| `numpy>=1.20.0` | Numerical operations for GL demos |
+
+## First Launch
+
+```bash
+python run.py
+```
+
+This opens the interactive menu. Navigate with arrow keys (or WASD), press Enter or Space to launch a demo, and press Escape or Q to return to the menu.
+
+You can also launch individual demos directly:
+
+```bash
+# Games
+python -c "from atari_style.demos.games.pacman import run_pacman; run_pacman()"
+python -c "from atari_style.demos.games.galaga import run_galaga; run_galaga()"
+python -c "from atari_style.demos.games.claugger import run_claugger; run_claugger()"
+
+# Visual demos
+python -c "from atari_style.demos.visualizers.starfield import run_starfield; run_starfield()"
+```
+
+## Try These First
+
+**For visuals**: Start with **Starfield**. It demonstrates the rendering engine at its best — 3D parallax layers, nebulae, warp tunnel, and asteroid mode. Use the joystick or left/right arrows to drift sideways.
+
+**For gameplay**: Try **Pac-Man**. It's the most complete game in the collection, with four ghost AI personalities, power-ups, and level progression that gives you an immediate sense of what the engine can do.
+
+**For something different**: **Claugger** is a Frogger tribute where you guide a chicken across traffic. It's the most recently added game and a good example of how to build a new demo from scratch.
+
+**For creative work**: **ASCII Painter** is a full drawing program with six tools, undo/redo, and file export. Press H in-game for the help overlay.
+
+## Controls
+
+All demos respond to both keyboard and joystick:
+
+| Keyboard | Joystick | Action |
+|---|---|---|
+| Arrow keys or WASD | Left analog stick | Navigate / Move |
+| Enter or Space | Button 0 (A/Cross) | Select / Fire / Action |
+| Escape or Q | Button 1 (B/Circle) | Back / Exit |
+| X | — | Force quit |
+
+## Troubleshooting
+
+**No joystick detected**
+
+The joystick is optional. The message "No joystick detected. Using keyboard only." at startup is informational, not an error. If you plug in a joystick mid-session, the input handler attempts reconnection automatically (roughly once per second).
+
+**Terminal too small**
+
+Some demos check terminal dimensions and may render incorrectly in small windows. Maximize your terminal or set it to at least 120x40 for the best experience. Grand Prix and the 3D demos benefit most from extra space.
+
+**Missing fonts for screenshots**
+
+Screenshot export (`save_screenshot`) uses Pillow to render a PNG. It looks for DejaVu Sans Mono, Liberation Mono, or Ubuntu Mono. If none are found it falls back to PIL's built-in bitmap font. Install a font package for better results:
+
+```bash
+# Debian/Ubuntu
+sudo apt install fonts-dejavu
+
+# Fedora
+sudo dnf install dejavu-sans-mono-fonts
+```
+
+**Colors look wrong**
+
+Make sure your terminal is set to use 256-color or truecolor mode. For bash/zsh, ensure `$TERM` is set to `xterm-256color` or similar:
+
+```bash
+export TERM=xterm-256color
+```
+
+**Import errors on startup**
+
+Confirm you activated the virtual environment and installed requirements:
+
+```bash
+source venv/bin/activate
+pip install -r requirements.txt
+```

--- a/docs/site/atari-style/tutorial.md
+++ b/docs/site/atari-style/tutorial.md
@@ -1,0 +1,313 @@
+---
+title: "Building Your First Game"
+weight: 4
+---
+
+# Building Your First Game
+
+This tutorial walks through building a complete bouncing ball demo from scratch. By the end you will have a working game that renders to the terminal, responds to keyboard and joystick input, and appears in the main menu.
+
+The complete source is at the bottom of this page. Each section builds on the last.
+
+## What We're Building
+
+A ball bounces around the terminal. Arrow keys or a joystick change its direction. ESC exits. Simple — but it touches every part of the engine.
+
+## Step 1: Create the File
+
+Create `atari_style/demos/games/bounce.py`.
+
+```python
+"""Bouncing ball demo."""
+
+import time
+from ...core.renderer import Renderer, Color
+from ...core.input_handler import InputHandler, InputType
+```
+
+The relative imports (`...core`) work because this file lives three package levels deep. If you put your demo elsewhere, adjust the number of dots.
+
+## Step 2: The Skeleton Class
+
+Every demo follows the same five-method pattern: `__init__`, `handle_input`, `update`, `draw`, `run`.
+
+```python
+class BouncingBall:
+    def __init__(self):
+        self.renderer = Renderer()
+        self.input_handler = InputHandler()
+
+        # Ball position (floats for smooth movement)
+        self.x = self.renderer.width / 2
+        self.y = self.renderer.height / 2
+
+        # Ball velocity in characters per second
+        self.vx = 20.0
+        self.vy = 10.0
+
+        self.running = True
+
+    def handle_input(self) -> bool:
+        """Return False to exit."""
+        inp = self.input_handler.get_input(timeout=0.016)
+
+        if inp == InputType.BACK:
+            return False
+        elif inp == InputType.UP:
+            self.vy = -abs(self.vy)
+        elif inp == InputType.DOWN:
+            self.vy = abs(self.vy)
+        elif inp == InputType.LEFT:
+            self.vx = -abs(self.vx)
+        elif inp == InputType.RIGHT:
+            self.vx = abs(self.vx)
+
+        return True
+
+    def update(self, dt: float):
+        """Advance physics by dt seconds."""
+        pass  # we'll add this in step 4
+
+    def draw(self):
+        """Render the current frame."""
+        pass  # we'll add this in step 3
+
+    def run(self):
+        self.renderer.enter_fullscreen()
+        last_time = time.time()
+        try:
+            while self.running:
+                now = time.time()
+                dt = now - last_time
+                last_time = now
+
+                if not self.handle_input():
+                    break
+                self.update(dt)
+                self.draw()
+        finally:
+            self.renderer.exit_fullscreen()
+            self.input_handler.cleanup()
+
+
+def run_bounce():
+    BouncingBall().run()
+```
+
+At this point the demo runs (try it: `python -c "from atari_style.demos.games.bounce import run_bounce; run_bounce()"`), but the screen is blank.
+
+## Step 3: Add Rendering
+
+Replace the `draw` method:
+
+```python
+def draw(self):
+    self.renderer.clear_buffer()
+
+    # Border so we can see the walls
+    self.renderer.draw_border(
+        0, 0,
+        self.renderer.width, self.renderer.height,
+        Color.CYAN
+    )
+
+    # Ball
+    bx = int(self.x)
+    by = int(self.y)
+    self.renderer.set_pixel(bx, by, 'O', Color.BRIGHT_YELLOW)
+
+    # HUD
+    self.renderer.draw_text(
+        2, 1,
+        f"Pos: ({bx}, {by})  Vel: ({self.vx:.0f}, {self.vy:.0f})",
+        Color.WHITE
+    )
+    self.renderer.draw_text(2, 2, "Arrows: change direction  ESC: exit", Color.GRAY)
+
+    self.renderer.render()
+```
+
+Three things happen every frame:
+1. `clear_buffer()` resets the buffer to empty
+2. Drawing calls (`draw_border`, `set_pixel`, `draw_text`) populate the buffer
+3. `render()` flushes the buffer to the terminal
+
+The ball is at `int(self.x), int(self.y)` because the renderer works in integer character coordinates, while physics uses floats.
+
+## Step 4: Add Physics
+
+Replace the `update` method:
+
+```python
+def update(self, dt: float):
+    # Move
+    self.x += self.vx * dt
+    self.y += self.vy * dt
+
+    # Bounce off left/right walls (leave 1-char margin for border)
+    if self.x < 1:
+        self.x = 1
+        self.vx = abs(self.vx)
+    elif self.x >= self.renderer.width - 1:
+        self.x = self.renderer.width - 2
+        self.vx = -abs(self.vx)
+
+    # Bounce off top/bottom walls
+    if self.y < 1:
+        self.y = 1
+        self.vy = abs(self.vy)
+    elif self.y >= self.renderer.height - 1:
+        self.y = self.renderer.height - 2
+        self.vy = -abs(self.vy)
+```
+
+Note the terminal aspect ratio: characters are taller than they are wide (approximately 2:1). The ball's X velocity (`20.0`) is higher than Y (`10.0`) to compensate, so it moves at roughly the same apparent speed in both directions.
+
+Run it again and you should see the ball bouncing around inside the border.
+
+## Step 5: Add to the Menu
+
+Open `atari_style/main.py` and find the games registration block. Add your demo:
+
+```python
+for game_id, title, desc, module, func in [
+    ("pacman", "Pac-Man", "Classic maze chase game with ghost AI",
+     "atari_style.demos.games.pacman", "run_pacman"),
+    # ... existing games ...
+    ("bounce", "Bouncing Ball",
+     "A ball bounces around. Arrows change direction.",
+     "atari_style.demos.games.bounce", "run_bounce"),  # add this
+]:
+```
+
+The registry uses lazy resolution — your module is not imported until the user actually selects the demo from the menu.
+
+Launch `python run.py` and your demo will appear in the Games section.
+
+## Complete Source
+
+```python
+"""Bouncing ball demo.
+
+A ball bounces around the terminal. Arrow keys or joystick change
+its direction. ESC exits.
+"""
+
+import time
+from typing import Tuple
+
+from ...core.renderer import Renderer, Color
+from ...core.input_handler import InputHandler, InputType
+
+
+class BouncingBall:
+    """Bouncing ball demo."""
+
+    def __init__(self) -> None:
+        self.renderer = Renderer()
+        self.input_handler = InputHandler()
+
+        # Ball position (floats for smooth movement)
+        self.x: float = self.renderer.width / 2.0
+        self.y: float = self.renderer.height / 2.0
+
+        # Velocity: characters per second
+        # X is higher than Y to compensate for terminal aspect ratio
+        self.vx: float = 20.0
+        self.vy: float = 10.0
+
+    def handle_input(self) -> bool:
+        """Process input. Returns False when the demo should exit."""
+        inp = self.input_handler.get_input(timeout=0.016)
+
+        if inp == InputType.BACK:
+            return False
+        elif inp == InputType.UP:
+            self.vy = -abs(self.vy)
+        elif inp == InputType.DOWN:
+            self.vy = abs(self.vy)
+        elif inp == InputType.LEFT:
+            self.vx = -abs(self.vx)
+        elif inp == InputType.RIGHT:
+            self.vx = abs(self.vx)
+
+        return True
+
+    def update(self, dt: float) -> None:
+        """Advance physics by dt seconds.
+
+        Args:
+            dt: Time since last frame in seconds.
+        """
+        self.x += self.vx * dt
+        self.y += self.vy * dt
+
+        # Bounce off walls (1-char margin for border)
+        if self.x < 1:
+            self.x = 1.0
+            self.vx = abs(self.vx)
+        elif self.x >= self.renderer.width - 1:
+            self.x = float(self.renderer.width - 2)
+            self.vx = -abs(self.vx)
+
+        if self.y < 1:
+            self.y = 1.0
+            self.vy = abs(self.vy)
+        elif self.y >= self.renderer.height - 1:
+            self.y = float(self.renderer.height - 2)
+            self.vy = -abs(self.vy)
+
+    def draw(self) -> None:
+        """Render the current frame to the terminal."""
+        self.renderer.clear_buffer()
+
+        # Border
+        self.renderer.draw_border(
+            0, 0,
+            self.renderer.width, self.renderer.height,
+            Color.CYAN,
+        )
+
+        # Ball
+        self.renderer.set_pixel(int(self.x), int(self.y), 'O', Color.BRIGHT_YELLOW)
+
+        # HUD
+        bx, by = int(self.x), int(self.y)
+        self.renderer.draw_text(
+            2, 1,
+            f"Pos: ({bx:3d}, {by:3d})  Vel: ({self.vx:+.0f}, {self.vy:+.0f})",
+            Color.WHITE,
+        )
+        self.renderer.draw_text(2, 2, "Arrows: change direction  ESC: exit", Color.GRAY)
+
+        self.renderer.render()
+
+    def run(self) -> None:
+        """Main loop."""
+        self.renderer.enter_fullscreen()
+        last_time = time.time()
+        try:
+            while True:
+                now = time.time()
+                dt = min(now - last_time, 0.1)  # cap dt to avoid huge jumps
+                last_time = now
+
+                if not self.handle_input():
+                    break
+                self.update(dt)
+                self.draw()
+        finally:
+            self.renderer.exit_fullscreen()
+            self.input_handler.cleanup()
+
+
+def run_bounce() -> None:
+    """Entry point for the bouncing ball demo."""
+    BouncingBall().run()
+```
+
+## Going Further
+
+The Claugger source (`atari_style/demos/games/claugger.py`) is a good next read. It shows how to handle lanes, collision detection, scoring, lives, and a title/game-over screen — all built on exactly the same pattern you used here.
+
+For analog joystick control (smooth rather than directional), look at Breakout (`atari_style/demos/games/breakout.py`), which uses `get_joystick_state()` to drive paddle position proportionally to the stick's X axis.

--- a/docs/superpowers/plans/2026-03-19-claugger-article-docs.md
+++ b/docs/superpowers/plans/2026-03-19-claugger-article-docs.md
@@ -1,0 +1,1239 @@
+# Claugger + Article + Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Frogger-style terminal game (Claugger), a late-90s Linux Journal blog article, project documentation, and a cross-repo publishing workflow — all serving issue #144 (project visibility).
+
+**Architecture:** Article-driven development. The blog article is the spine — the game exists to prove its thesis, the docs exist so readers can go deeper. Claugger follows the existing game pattern (class with `__init__`, `update`, `draw`, `handle_input`, `run`) using `Renderer`/`InputHandler` from `atari_style.core`. Docs and blog are Hugo-compatible markdown published via cross-repo `repository_dispatch`.
+
+**Tech Stack:** Python 3.8+, blessed (terminal rendering), pygame (joystick), Hugo + PaperMod (docs site), GitHub Actions (publishing)
+
+**Spec:** `docs/superpowers/specs/2026-03-19-claugger-article-docs-design.md`
+
+---
+
+## File Map
+
+### New Files
+
+| File | Responsibility |
+|------|----------------|
+| `atari_style/demos/games/claugger.py` | Claugger game implementation (~900-1100 lines) |
+| `tests/test_claugger.py` | Game unit tests (lanes, collision, eggs, scoring, easter eggs) |
+| `docs/blog/2026-03-19-claugger-terminal-arcade.md` | Blog article (Hugo markdown) |
+| `docs/site/atari-style/getting-started.md` | Quickstart guide |
+| `docs/site/atari-style/architecture.md` | Architecture overview |
+| `docs/site/atari-style/api-reference.md` | Core module API reference |
+| `docs/site/atari-style/tutorial.md` | "Build Your First Game" tutorial |
+| `docs/site/atari-style/contributing.md` | Contributor guide |
+| `.github/workflows/publish-docs.yml` | Cross-repo dispatch workflow |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `atari_style/main.py` | Add Claugger to registry and menu |
+
+---
+
+## Task 1: Article Outline
+
+Write the article outline first — this drives what the game needs to demonstrate and what the docs need to cover.
+
+**Files:**
+- Create: `docs/blog/2026-03-19-claugger-terminal-arcade.md`
+
+- [ ] **Step 1: Create blog directory**
+
+```bash
+mkdir -p docs/blog
+```
+
+- [ ] **Step 2: Write the article outline with Hugo front matter**
+
+Create `docs/blog/2026-03-19-claugger-terminal-arcade.md` with PaperMod front matter and section headers. Each section should have 2-3 bullet points capturing the key beats. The full prose comes later (Task 8) after the game is built and we have real code snippets to reference.
+
+Front matter format:
+```yaml
+---
+title: "Why Did the Chicken Cross the Terminal? Building Arcade Games Where Nobody Expected Them"
+date: 2026-03-19
+description: "A manifesto for terminal gaming and a walkthrough of building Claugger, a Frogger clone starring an ASCII chicken"
+tags: ["python", "terminal", "gamedev", "ascii", "atari-style"]
+author: "jcaldwell"
+showToc: true
+TocOpen: true
+---
+```
+
+Sections per spec: Cold Open, The Thesis (Terminals as Canvas), The Toolkit, Building Claugger, The Bigger Picture, Closing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/blog/2026-03-19-claugger-terminal-arcade.md
+git commit -m "docs: Add article outline for Claugger terminal arcade post"
+```
+
+---
+
+## Task 2: Claugger Game Skeleton + Lane System
+
+Build the foundational game structure: class skeleton, lane data model, and scrolling objects. No chicken, no collision, no eggs yet — just the world the chicken will inhabit.
+
+**Files:**
+- Create: `atari_style/demos/games/claugger.py`
+- Create: `tests/test_claugger.py`
+
+- [ ] **Step 1: Write failing tests for lane data model**
+
+Create `tests/test_claugger.py`. Test that:
+- A `Lane` can be created with direction, speed, and lane type (ROAD/RIVER/SAFE/START/GOAL)
+- Lane objects scroll horizontally and wrap around screen edges
+- Road lanes contain vehicle objects with correct widths (car=4, truck=6, motorcycle=2)
+- River lanes contain log objects (5-8 chars) and turtle groups (2-3 `@` chars)
+- 13 lanes are created in correct order (start, 5 road, median, 5 river, goal)
+
+```python
+"""Tests for Claugger game."""
+
+import random
+import unittest
+from atari_style.demos.games.claugger import (
+    Lane, LaneType, LaneObject, Claugger,
+    LANE_COUNT, ROWS_PER_LANE,
+)
+
+
+class TestLaneModel(unittest.TestCase):
+    """Test lane data structures."""
+
+    def test_lane_count(self):
+        """13 logical lanes in the game."""
+        self.assertEqual(LANE_COUNT, 13)
+
+    def test_rows_per_lane(self):
+        """Each lane renders as 3 terminal rows."""
+        self.assertEqual(ROWS_PER_LANE, 3)
+
+    def test_road_lane_creation(self):
+        """Road lane has correct type and direction."""
+        lane = Lane(lane_type=LaneType.ROAD, speed=2.0, direction=1)
+        self.assertEqual(lane.lane_type, LaneType.ROAD)
+        self.assertEqual(lane.direction, 1)
+
+    def test_lane_object_wraps(self):
+        """Objects wrap around when they scroll past screen edge."""
+        obj = LaneObject(x=78.0, width=4, chars="AUTO")
+        obj.x += 3  # Push past 80-col screen
+        screen_width = 80
+        if obj.x >= screen_width:
+            obj.x = -obj.width
+        self.assertEqual(obj.x, -4)
+
+    def test_river_lane_creation(self):
+        """River lane has correct type."""
+        lane = Lane(lane_type=LaneType.RIVER, speed=1.5, direction=-1)
+        self.assertEqual(lane.lane_type, LaneType.RIVER)
+
+
+class TestTerminalSize(unittest.TestCase):
+    """Test terminal size requirements."""
+
+    def test_min_dimensions_constants(self):
+        """Game defines minimum terminal dimensions."""
+        from atari_style.demos.games.claugger import MIN_TERM_HEIGHT, MIN_TERM_WIDTH
+        self.assertEqual(MIN_TERM_HEIGHT, 44)
+        self.assertEqual(MIN_TERM_WIDTH, 80)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+python -m unittest tests.test_claugger -v
+```
+
+Expected: ImportError — `claugger` module doesn't exist yet.
+
+- [ ] **Step 3: Implement game skeleton with lane system**
+
+Create `atari_style/demos/games/claugger.py` with:
+
+1. Module docstring, imports (`time`, `random`, `Renderer`, `Color`, `InputHandler`, `InputType`)
+2. Constants: `LANE_COUNT = 13`, `ROWS_PER_LANE = 3`, `HUD_ROWS = 3`, `MIN_TERM_HEIGHT = 44`, `MIN_TERM_WIDTH = 80`, `TARGET_FPS = 30`
+3. `LaneType` enum: `START`, `ROAD`, `SAFE`, `RIVER`, `GOAL`
+4. `LaneObject` dataclass: `x: float`, `width: int`, `chars: str`, `color: str`, `is_diving: bool = False`, `dive_timer: float = 0.0`, `dive_phase: float = 0.0` (for turtles)
+5. `Lane` dataclass: `lane_type: LaneType`, `speed: float`, `direction: int` (+1 right, -1 left), `objects: list[LaneObject]`
+6. `Claugger` class with:
+   - `__init__()`: create Renderer, InputHandler, build 13 lanes with objects, init game state
+   - `_build_lanes(level: int) -> list[Lane]`: generate lane configuration for given level
+   - `_spawn_road_objects(lane, density)`: populate road lane with cars/trucks/motorcycles
+   - `_spawn_river_objects(lane)`: populate river lane with logs and turtle groups
+   - `update(dt)`: scroll all lane objects, handle wrap-around, tick turtle dive timers
+   - `draw()`: render lanes and objects (no chicken yet)
+   - `run()`: main loop skeleton (enter_fullscreen, loop with dt calc, exit_fullscreen in finally). On startup, check terminal dimensions against `MIN_TERM_HEIGHT` and `MIN_TERM_WIDTH` — if too small, display "Please resize your terminal to at least 80x44" and wait for resize before proceeding.
+   - `run_claugger()` entry function
+7. Vehicle ASCII art constants:
+   - `CAR_SPRITES`: list of 4-char vehicle strings (e.g., `">==>"`, `"<##<"`, `"[==]"`)
+   - `TRUCK_SPRITES`: list of 6-char truck strings (e.g., `">====>"`  `"<####<"`)
+   - `MOTORCYCLE_SPRITES`: list of 2-char sprites (e.g., `"o>"`, `"<o"`)
+   - `LOG_CHAR = "="`, `TURTLE_CHAR = "@"`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python -m unittest tests.test_claugger -v
+```
+
+Expected: All 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add atari_style/demos/games/claugger.py tests/test_claugger.py
+git commit -m "feat(claugger): Add game skeleton with lane system and scrolling objects"
+```
+
+---
+
+## Task 3: Chicken Sprite + Movement
+
+Add the chicken character with directional sprites, movement between lanes (instantaneous snap), and basic input handling.
+
+**Files:**
+- Modify: `atari_style/demos/games/claugger.py`
+- Modify: `tests/test_claugger.py`
+
+- [ ] **Step 1: Write failing tests for chicken movement**
+
+Add to `tests/test_claugger.py`:
+
+```python
+class TestChicken(unittest.TestCase):
+    """Test chicken sprite and movement."""
+
+    def test_chicken_starts_at_lane_1(self):
+        """Chicken starts in the henhouse (lane 0, bottom)."""
+        game = Claugger()
+        self.assertEqual(game.chicken_lane, 0)
+
+    def test_chicken_moves_up(self):
+        """Moving up increments lane by 1."""
+        game = Claugger()
+        game.move_chicken(0, 1)  # dx=0, dy=1 (up)
+        self.assertEqual(game.chicken_lane, 1)
+
+    def test_chicken_cannot_move_below_start(self):
+        """Chicken cannot move below lane 0."""
+        game = Claugger()
+        game.move_chicken(0, -1)
+        self.assertEqual(game.chicken_lane, 0)
+
+    def test_chicken_cannot_move_above_goal(self):
+        """Chicken cannot move above lane 12."""
+        game = Claugger()
+        game.chicken_lane = 12
+        game.move_chicken(0, 1)
+        self.assertEqual(game.chicken_lane, 12)
+
+    def test_chicken_horizontal_movement(self):
+        """Chicken can move left and right within screen bounds."""
+        game = Claugger()
+        start_x = game.chicken_x
+        game.move_chicken(1, 0)
+        self.assertEqual(game.chicken_x, start_x + 3)  # 3 = sprite width
+
+    def test_chicken_has_facing_direction(self):
+        """Chicken facing changes with movement."""
+        game = Claugger()
+        game.move_chicken(0, 1)
+        self.assertEqual(game.chicken_facing, "up")
+        game.move_chicken(1, 0)
+        self.assertEqual(game.chicken_facing, "right")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+python -m unittest tests.test_claugger.TestChicken -v
+```
+
+Expected: AttributeError — chicken attributes don't exist yet.
+
+- [ ] **Step 3: Implement chicken sprite and movement**
+
+Add to `claugger.py`:
+
+1. `CHICKEN_SPRITES` dict with directional 3x2 ASCII art:
+   ```python
+   CHICKEN_SPRITES = {
+       "up":    [r" /\ ", r"/~~\\"],
+       "down":  [r" \/ ", r"\\__/"],
+       "left":  [r"<\\ ", r" \\>"],
+       "right": [r" //>" , r"<// "],
+       "idle":  [r" >Q<", r" /\\ "],
+   }
+   ```
+   (Exact art will be refined during implementation — these are placeholders showing the 3x2 structure)
+
+2. Chicken state in `__init__`:
+   - `self.chicken_x: int` — horizontal position (column)
+   - `self.chicken_lane: int` — current lane (0-12)
+   - `self.chicken_facing: str` — "up", "down", "left", "right", "idle"
+   - `self.chicken_frame: int` — animation frame (0 or 1)
+   - `self.chicken_hop_timer: float` — brief visual hop countdown
+
+3. `move_chicken(dx, dy)` method:
+   - Validate bounds: lane 0-12, x within screen
+   - Update `chicken_lane` atomically (instantaneous snap per spec)
+   - Update `chicken_facing` based on direction
+   - Set `chicken_hop_timer = 0.1` for 2-frame visual
+
+4. Update `handle_input()` to call `move_chicken()` on arrow keys
+5. Update `draw()` to render chicken sprite at correct position
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python -m unittest tests.test_claugger -v
+```
+
+Expected: All tests PASS (both TestLaneModel and TestChicken).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add atari_style/demos/games/claugger.py tests/test_claugger.py
+git commit -m "feat(claugger): Add chicken sprite with directional movement and lane snapping"
+```
+
+---
+
+## Task 4: Collision Detection + Death Animations
+
+Add collision between chicken and vehicles (death on road), water (death if not on log/turtle), and riding mechanics on river objects.
+
+**Files:**
+- Modify: `atari_style/demos/games/claugger.py`
+- Modify: `tests/test_claugger.py`
+
+- [ ] **Step 1: Write failing tests for collision**
+
+```python
+class TestCollision(unittest.TestCase):
+    """Test collision detection."""
+
+    def test_road_collision_kills_chicken(self):
+        """Chicken dies when overlapping a vehicle."""
+        game = Claugger()
+        game.chicken_lane = 1  # First road lane
+        # Place a car directly on the chicken
+        game.lanes[1].objects[0].x = float(game.chicken_x)
+        game.check_collisions()
+        self.assertEqual(game.state, Claugger.STATE_DYING)
+
+    def test_no_collision_when_not_overlapping(self):
+        """Chicken is safe when no vehicle overlap."""
+        game = Claugger()
+        game.chicken_lane = 1
+        # Move all objects far from chicken
+        for obj in game.lanes[1].objects:
+            obj.x = -20.0
+        game.check_collisions()
+        self.assertNotEqual(game.state, Claugger.STATE_DYING)
+
+    def test_river_no_object_kills_chicken(self):
+        """Chicken drowns when on river lane without a log/turtle."""
+        game = Claugger()
+        game.chicken_lane = 7  # First river lane
+        # Move all objects away
+        for obj in game.lanes[7].objects:
+            obj.x = -20.0
+        game.check_collisions()
+        self.assertEqual(game.state, Claugger.STATE_DYING)
+
+    def test_river_on_log_is_safe(self):
+        """Chicken is safe when standing on a log."""
+        game = Claugger()
+        game.chicken_lane = 7
+        # Place a log under the chicken
+        game.lanes[7].objects[0].x = float(game.chicken_x)
+        game.lanes[7].objects[0].width = 6
+        game.check_collisions()
+        self.assertNotEqual(game.state, Claugger.STATE_DYING)
+
+    def test_chicken_rides_log(self):
+        """Chicken moves with the log it's standing on."""
+        game = Claugger()
+        game.chicken_lane = 7
+        game.lanes[7].objects[0].x = float(game.chicken_x)
+        game.lanes[7].objects[0].width = 6
+        start_x = game.chicken_x
+        game.update_river_riding(0.1)
+        # Chicken x should have shifted by lane speed * direction * dt
+        self.assertNotEqual(game.chicken_x, start_x)
+
+    def test_turtle_dive_kills_chicken(self):
+        """Chicken drowns when turtle it's on dives."""
+        game = Claugger()
+        game.chicken_lane = 7
+        turtle = game.lanes[7].objects[0]
+        turtle.x = float(game.chicken_x)
+        turtle.is_diving = True
+        game.check_collisions()
+        self.assertEqual(game.state, Claugger.STATE_DYING)
+
+    def test_collision_uses_bounding_box(self):
+        """Collision checks full 3x2 sprite area."""
+        game = Claugger()
+        game.chicken_lane = 1
+        # Place car overlapping just the right edge of the chicken
+        game.lanes[1].objects[0].x = float(game.chicken_x + 2)  # Overlaps rightmost col
+        game.lanes[1].objects[0].width = 4
+        game.check_collisions()
+        self.assertEqual(game.state, Claugger.STATE_DYING)
+
+    def test_turtle_dive_cycle_timing(self):
+        """Turtles dive for 2s and surface for 4s."""
+        game = Claugger()
+        # Find a turtle object in a river lane
+        turtle = None
+        for lane in game.lanes:
+            if lane.lane_type == LaneType.RIVER:
+                for obj in lane.objects:
+                    if obj.chars and "@" in obj.chars:
+                        turtle = obj
+                        break
+            if turtle:
+                break
+        if turtle is None:
+            self.skipTest("No turtle found in lanes")
+        # Surface phase should be 4 seconds
+        turtle.is_diving = False
+        turtle.dive_timer = 0.0
+        game.update_turtle_dives(4.0)
+        self.assertTrue(turtle.is_diving)
+        # Dive phase should last 2 seconds
+        turtle.dive_timer = 0.0
+        game.update_turtle_dives(2.0)
+        self.assertFalse(turtle.is_diving)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+python -m unittest tests.test_claugger.TestCollision -v
+```
+
+Expected: AttributeError — `check_collisions` and `STATE_DYING` don't exist.
+
+- [ ] **Step 3: Implement collision detection and death states**
+
+Add to `claugger.py`:
+
+1. Game states as class constants:
+   ```python
+   STATE_TITLE = 0
+   STATE_PLAYING = 1
+   STATE_DYING = 2
+   STATE_GAME_OVER = 3
+   STATE_LEVEL_COMPLETE = 4
+   STATE_READY = 5
+   ```
+
+2. `check_collisions()` method:
+   - Get current lane by `self.chicken_lane`
+   - If lane is ROAD: check bounding box overlap between chicken (x, x+3) and each vehicle object (obj.x, obj.x+obj.width). Any overlap → `STATE_DYING`
+   - If lane is RIVER: check if chicken bounding box overlaps any non-diving object. If no overlap with any object → `STATE_DYING` (drowning). If on a diving turtle → `STATE_DYING`
+   - SAFE, START, GOAL lanes: no collision
+
+3. `update_river_riding(dt)` method:
+   - If on a river lane and overlapping a log/turtle, shift `chicken_x` by `lane.speed * lane.direction * dt`
+
+4. Death animation state:
+   - `self.death_type`: "squash", "drown", "timeout"
+   - `self.death_timer: float` — counts down death animation (1.5 seconds)
+   - Death animation sprites per type
+   - `DEATH_MESSAGES` list for rotating puns
+   - After death timer expires: decrement lives, respawn at lane 0, or STATE_GAME_OVER if lives == 0
+
+5. `update_turtle_dives(dt)` method:
+   - Each turtle group has a `dive_timer` that counts up
+   - When surfaced (`is_diving=False`): after 4 seconds, set `is_diving=True`, reset timer
+   - When diving (`is_diving=True`): after 2 seconds, set `is_diving=False`, reset timer
+   - Initial `dive_phase` offsets stagger groups so they don't all dive at once
+
+6. Update `update(dt)` to call `check_collisions()` and `update_turtle_dives(dt)` during STATE_PLAYING, handle STATE_DYING countdown.
+7. Update `draw()` to render death animation and message when STATE_DYING. Hide diving turtles.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python -m unittest tests.test_claugger -v
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add atari_style/demos/games/claugger.py tests/test_claugger.py
+git commit -m "feat(claugger): Add collision detection, death animations, and river riding"
+```
+
+---
+
+## Task 5: Scoring, Lives, Timer, and HUD
+
+Add the scoring system, lives, egg timer countdown, nest filling, level progression, and the pun-filled HUD.
+
+**Files:**
+- Modify: `atari_style/demos/games/claugger.py`
+- Modify: `tests/test_claugger.py`
+
+- [ ] **Step 1: Write failing tests for scoring and game progression**
+
+```python
+class TestScoring(unittest.TestCase):
+    """Test scoring, lives, and level progression."""
+
+    def test_initial_score_is_zero(self):
+        game = Claugger()
+        self.assertEqual(game.score, 0)
+
+    def test_initial_lives_is_three(self):
+        game = Claugger()
+        self.assertEqual(game.lives, 3)
+
+    def test_forward_hop_awards_points(self):
+        """Moving forward awards 10 points per lane."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.move_chicken(0, 1)
+        self.assertEqual(game.score, 10)
+
+    def test_reaching_nest_awards_bonus(self):
+        """Filling a nest awards 50 points + time bonus."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.chicken_lane = 12
+        game.fill_nest()
+        self.assertGreater(game.score, 50)
+
+    def test_five_nests_completes_level(self):
+        """Filling all 5 nests triggers level complete."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.nests_filled = 4
+        game.chicken_lane = 12
+        game.fill_nest()
+        self.assertEqual(game.state, Claugger.STATE_LEVEL_COMPLETE)
+
+    def test_timer_resets_on_death(self):
+        """Timer resets when chicken respawns."""
+        game = Claugger()
+        game.timer = 30.0
+        game.respawn_chicken()
+        self.assertEqual(game.timer, 60.0)
+
+    def test_timer_does_not_reset_on_nest_fill(self):
+        """Timer keeps running when a nest is filled mid-level."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.timer = 30.0
+        game.chicken_lane = 12
+        game.fill_nest()
+        self.assertLessEqual(game.timer, 30.0)
+
+    def test_level_progression_increases_speed(self):
+        """Higher levels have faster lane speeds."""
+        game = Claugger()
+        level1_speeds = [l.speed for l in game.lanes if l.lane_type == LaneType.ROAD]
+        game.next_level()
+        level2_speeds = [l.speed for l in game.lanes if l.lane_type == LaneType.ROAD]
+        self.assertTrue(all(s2 > s1 for s1, s2 in zip(level1_speeds, level2_speeds)))
+
+    def test_timer_expiry_kills_chicken(self):
+        """Chicken dies when timer reaches zero."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.timer = 0.01
+        game.update(0.02)
+        self.assertEqual(game.state, Claugger.STATE_DYING)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+python -m unittest tests.test_claugger.TestScoring -v
+```
+
+- [ ] **Step 3: Implement scoring, lives, timer, nests, and HUD**
+
+Add to `claugger.py`:
+
+1. Game state in `__init__`:
+   - `self.score = 0`
+   - `self.lives = 3`
+   - `self.level = 1`
+   - `self.timer = 60.0`
+   - `self.nests_filled = 0`
+   - `self.nests = [False] * 5` — tracks which nest positions are filled
+   - `self.highest_lane_this_life = 0` — prevents re-scoring same lane
+
+2. Scoring rules in `move_chicken()`:
+   - Award 10 points per new forward lane reached (track with `highest_lane_this_life`)
+   - Reset `highest_lane_this_life` on respawn
+
+3. `fill_nest()` method:
+   - Award 50 points + (remaining_timer * 2) time bonus
+   - Mark nest as filled
+   - If all 5 nests filled → `STATE_LEVEL_COMPLETE`
+   - Respawn chicken at lane 0
+
+4. `respawn_chicken()`: reset position, timer to 60.0, `highest_lane_this_life` to 0
+5. `next_level()`: increment level, rebuild lanes with `_build_lanes(self.level)`, reset nests, reset timer
+
+6. Timer in `update(dt)`:
+   - Decrement `self.timer -= dt` during STATE_PLAYING
+   - If timer <= 0: death by timeout
+
+7. HUD in `draw()`:
+   - Top 3 rows of screen:
+   - Row 0: `"EGGS-cellent: {score:,}"` left, `"Crossing #{level}"` center, `">Q< " * lives` right
+   - Row 1: egg timer bar (visual bar that shrinks from 40 chars to 0 as timer drains)
+   - Row 2: death message or level complete message (fades after 2 seconds)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python -m unittest tests.test_claugger -v
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add atari_style/demos/games/claugger.py tests/test_claugger.py
+git commit -m "feat(claugger): Add scoring, lives, timer, nest filling, and HUD"
+```
+
+---
+
+## Task 6: Egg-Laying Bonus System
+
+Add the egg-laying mechanic: 5% chance per hop, lane persistence, vehicle squashing, river scrolling, and the EGGS-tra life bonus.
+
+**Files:**
+- Modify: `atari_style/demos/games/claugger.py`
+- Modify: `tests/test_claugger.py`
+
+- [ ] **Step 1: Write failing tests for egg mechanics**
+
+```python
+class TestEggs(unittest.TestCase):
+    """Test egg-laying bonus system."""
+
+    def test_egg_not_laid_on_safe_median(self):
+        """No eggs on safe zones."""
+        game = Claugger()
+        game.chicken_lane = 6  # Safe median
+        game.try_lay_egg()
+        self.assertEqual(len(game.eggs), 0)
+
+    def test_egg_laid_on_road(self):
+        """Eggs can be laid on road lanes."""
+        game = Claugger()
+        game.chicken_lane = 1
+        random.seed(42)  # Seed for deterministic test
+        # Force lay by calling with override
+        game.lay_egg()
+        self.assertEqual(len(game.eggs), 1)
+        self.assertEqual(game.eggs[0].lane, 1)
+
+    def test_egg_on_river_scrolls_with_object(self):
+        """Eggs on river objects move with the object."""
+        game = Claugger()
+        game.chicken_lane = 7
+        # Place chicken on a log
+        log = game.lanes[7].objects[0]
+        log.x = float(game.chicken_x)
+        game.lay_egg()
+        egg = game.eggs[0]
+        self.assertIsNotNone(egg.attached_object)
+
+    def test_egg_squashed_by_vehicle(self):
+        """Vehicles destroy eggs on road lanes."""
+        game = Claugger()
+        game.chicken_lane = 1
+        game.lay_egg()
+        egg = game.eggs[0]
+        # Move a vehicle onto the egg
+        game.lanes[1].objects[0].x = egg.x
+        game.update_eggs(0.1)
+        self.assertTrue(egg.squashed)
+
+    def test_ten_eggs_award_extra_life(self):
+        """Collecting 10 eggs gives an extra life."""
+        game = Claugger()
+        game.total_eggs_laid = 9
+        game.lay_egg()
+        self.assertEqual(game.lives, 4)  # Started with 3
+
+    def test_eggs_award_points_on_level_complete(self):
+        """Surviving eggs are worth 200 points each on level complete."""
+        game = Claugger()
+        game.lay_egg_at(lane=1, x=10)
+        game.lay_egg_at(lane=2, x=20)
+        points = game.score_eggs()
+        self.assertEqual(points, 400)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+python -m unittest tests.test_claugger.TestEggs -v
+```
+
+- [ ] **Step 3: Implement egg system**
+
+Add to `claugger.py`:
+
+1. `Egg` dataclass: `x: float`, `lane: int`, `attached_object: LaneObject | None`, `squashed: bool = False`, `splat_timer: float = 0.0`
+2. Game state: `self.eggs: list[Egg] = []`, `self.total_eggs_laid = 0`
+3. `try_lay_egg()`: 5% random chance, calls `lay_egg()` if successful. No eggs on SAFE, START, or GOAL lanes.
+4. `lay_egg()`: create Egg at chicken position. If on river, attach to the log/turtle object.
+5. `lay_egg_at(lane, x)`: helper for deterministic egg placement (used by tests and Konami Code).
+6. `update_eggs(dt)`:
+   - Road eggs: check collision with vehicles → set `squashed = True`, start splat animation
+   - River eggs: move with attached object. If object off-screen, remove egg.
+   - Remove squashed eggs after splat animation (0.5s)
+7. `score_eggs() -> int`: count non-squashed eggs × 200 points. Called on level complete.
+8. EGGS-tra life check: when `total_eggs_laid` reaches 10, 20, 30... award extra life.
+9. Hook into `move_chicken()`: call `try_lay_egg()` on each hop.
+10. Hook into `fill_nest()` / level complete: call `score_eggs()`.
+11. Draw eggs as `"o"` on screen, squashed eggs as `"*"` briefly.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python -m unittest tests.test_claugger -v
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add atari_style/demos/games/claugger.py tests/test_claugger.py
+git commit -m "feat(claugger): Add egg-laying bonus system with road squashing and river scrolling"
+```
+
+---
+
+## Task 7: Easter Eggs + Title Screen + Game Over
+
+Add the Konami Code golden rooster, Road Scholar achievement, title screen, and game over screen.
+
+**Files:**
+- Modify: `atari_style/demos/games/claugger.py`
+- Modify: `tests/test_claugger.py`
+
+- [ ] **Step 1: Write failing tests for easter eggs**
+
+```python
+class TestEasterEggs(unittest.TestCase):
+    """Test easter egg triggers."""
+
+    def test_konami_code_detection(self):
+        """Konami sequence activates golden rooster."""
+        game = Claugger()
+        sequence = [
+            InputType.UP, InputType.UP,
+            InputType.DOWN, InputType.DOWN,
+            InputType.LEFT, InputType.RIGHT,
+            InputType.LEFT, InputType.RIGHT,
+            InputType.SELECT, InputType.BACK,
+        ]
+        for inp in sequence:
+            game.record_input(inp)
+        self.assertTrue(game.golden_rooster_active)
+
+    def test_konami_code_single_use(self):
+        """Golden rooster can only be triggered once per session."""
+        game = Claugger()
+        game.golden_rooster_used = True
+        sequence = [
+            InputType.UP, InputType.UP,
+            InputType.DOWN, InputType.DOWN,
+            InputType.LEFT, InputType.RIGHT,
+            InputType.LEFT, InputType.RIGHT,
+            InputType.SELECT, InputType.BACK,
+        ]
+        for inp in sequence:
+            game.record_input(inp)
+        self.assertFalse(game.golden_rooster_active)
+
+    def test_road_scholar_triggers_after_3_deathless_levels(self):
+        """Road Scholar triggers after completing 3 levels without dying."""
+        game = Claugger()
+        game.consecutive_deathless_levels = 2
+        game.next_level()
+        self.assertTrue(game.road_scholar_triggered)
+
+    def test_road_scholar_awards_bonus(self):
+        """Road Scholar awards 5000 points."""
+        game = Claugger()
+        game.consecutive_deathless_levels = 2
+        score_before = game.score
+        game.next_level()
+        self.assertEqual(game.score - score_before, 5000)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+python -m unittest tests.test_claugger.TestEasterEggs -v
+```
+
+- [ ] **Step 3: Implement easter eggs, title screen, and game over**
+
+Add to `claugger.py`:
+
+1. Konami Code tracker:
+   - `KONAMI_SEQUENCE` constant
+   - `self.input_buffer: list[InputType]` — rolling buffer of last 10 inputs
+   - `record_input(input_type)`: append to buffer, check if tail matches KONAMI_SEQUENCE
+   - `self.golden_rooster_active = False`, `self.golden_rooster_used = False`, `self.golden_rooster_timer = 5.0`
+   - When active: swap chicken sprites for golden variants (yellow colored), invincibility for 5s, lay golden eggs (500 pts each)
+
+2. Road Scholar tracker:
+   - `self.consecutive_deathless_levels = 0`
+   - `self.deaths_this_level = 0`
+   - On death: `deaths_this_level += 1`
+   - On level complete: if `deaths_this_level == 0`: increment `consecutive_deathless_levels`. If reaches 3: trigger Road Scholar.
+   - `self.road_scholar_triggered = False`
+   - Road Scholar animation: brief diploma ASCII art, "ROAD SCHOLAR" text, 5000 points
+
+3. Title screen (STATE_TITLE):
+   - Large ASCII art "CLAUGGER" title
+   - Chicken ASCII art
+   - "Press ENTER to start" / "Why did the chicken cross the road?"
+   - Konami Code works here
+
+4. Game over screen (STATE_GAME_OVER):
+   - "THE ROOST IS COOKED"
+   - Final stats: score, level reached, eggs laid, nests filled
+   - "Press ENTER to play again"
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python -m unittest tests.test_claugger -v
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add atari_style/demos/games/claugger.py tests/test_claugger.py
+git commit -m "feat(claugger): Add easter eggs, title screen, and game over screen"
+```
+
+---
+
+## Task 8: Menu Registration + Integration Test
+
+Register Claugger in ContentRegistry and main menu. Verify the game launches from the menu.
+
+**Files:**
+- Modify: `atari_style/main.py`
+- Modify: `atari_style/demos/games/claugger.py`
+
+- [ ] **Step 1: Write failing test for registry integration**
+
+Add to `tests/test_claugger.py`:
+
+```python
+class TestRegistration(unittest.TestCase):
+    """Test Claugger registration in ContentRegistry."""
+
+    def test_claugger_importable(self):
+        """run_claugger function is importable."""
+        from atari_style.demos.games.claugger import run_claugger
+        self.assertTrue(callable(run_claugger))
+
+    def test_claugger_in_registry(self):
+        """Claugger appears in the content registry."""
+        from atari_style.core.registry import ContentRegistry
+        reg = ContentRegistry()
+        # Simulate the registration that main.py does
+        from atari_style.main import _build_registry
+        reg = _build_registry()
+        entry = reg.get("claugger")
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.title, "Claugger")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+python -m unittest tests.test_claugger.TestRegistration -v
+```
+
+Expected: `get("claugger")` returns None — not registered yet.
+
+- [ ] **Step 3: Add Claugger to registry and menu**
+
+In `atari_style/main.py`, add to `_build_registry()`:
+
+```python
+reg.register_metadata(ContentMetadata(
+    id="claugger",
+    title="Claugger",
+    category=ContentCategory.GAME,
+    description="Why did the chicken cross the road? A Frogger tribute.",
+    run_module="atari_style.demos.games.claugger",
+    run_function_name="run_claugger",
+))
+```
+
+Add to the Games section of the menu items list.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+python -m unittest tests.test_claugger -v
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Smoke test — launch the game manually**
+
+```bash
+python -c "from atari_style.demos.games.claugger import run_claugger; run_claugger()"
+```
+
+Verify: title screen appears, chicken moves, vehicles scroll, collision works, HUD shows score/lives/timer. Press ESC to exit cleanly.
+
+- [ ] **Step 6: Run full test suite and linter**
+
+```bash
+ruff check atari_style/ tests/
+python -m unittest discover -s tests -p "test_*.py" -v
+```
+
+Expected: All checks pass, no regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add atari_style/main.py atari_style/demos/games/claugger.py tests/test_claugger.py
+git commit -m "feat(claugger): Register in ContentRegistry and add to game menu"
+```
+
+---
+
+## Task 9: Blog Article — Full Draft
+
+Write the complete article with real code snippets from the now-built Claugger game.
+
+**Files:**
+- Modify: `docs/blog/2026-03-19-claugger-terminal-arcade.md`
+
+- [ ] **Step 1: Read key code sections for article snippets**
+
+Read these from the now-built `claugger.py` to extract real code for the article:
+- Chicken sprite definitions
+- Lane setup / `_build_lanes()`
+- Collision detection logic
+- Egg-laying mechanic
+- HUD rendering
+- Entry function and menu registration
+
+Also read:
+- `atari_style/core/renderer.py` — key method signatures for the Toolkit section
+- `atari_style/core/input_handler.py` — InputHandler overview for the Toolkit section
+- `PHILOSOPHY.md` — for the Thesis section
+
+- [ ] **Step 2: Write the full article**
+
+Replace the outline in `docs/blog/2026-03-19-claugger-terminal-arcade.md` with the complete ~2500-3500 word article.
+
+Voice: Late-90s Linux Journal. Practical, irreverent, opinionated. Write like someone who's genuinely excited about terminals and slightly bemused that anyone would use Electron for anything.
+
+Sections per spec:
+1. **Cold Open** (~200 words) — Scene-setting, running the game, the delight
+2. **The Thesis** (~400 words) — "The terminal is a canvas, not a cage." History, constraints breed creativity
+3. **The Toolkit** (~500 words) — blessed, pygame, Renderer, InputHandler. Real code snippets from the codebase. Link to architecture docs.
+4. **Building Claugger** (~1200 words) — Walk through the game in stages with real code snippets. The chicken, the lanes, collision, eggs, HUD. Link to full source.
+5. **The Bigger Picture** (~400 words) — The full project, modular architecture, other games. Link to contributor guide.
+6. **Closing** (~200 words) — Chickens, terminals, open source.
+
+Include links to docs: `https://jcaldwell-labs.github.io/docs/atari-style/architecture/`, `/api-reference/`, `/tutorial/`, `/contributing/`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/blog/2026-03-19-claugger-terminal-arcade.md
+git commit -m "docs: Write full Claugger terminal arcade blog article"
+```
+
+---
+
+## Task 10: Project Documentation — 5 Pages
+
+Write all 5 documentation pages for the docs site.
+
+**Files:**
+- Create: `docs/site/atari-style/getting-started.md`
+- Create: `docs/site/atari-style/architecture.md`
+- Create: `docs/site/atari-style/api-reference.md`
+- Create: `docs/site/atari-style/tutorial.md`
+- Create: `docs/site/atari-style/contributing.md`
+
+- [ ] **Step 1: Create docs directory**
+
+```bash
+mkdir -p docs/site/atari-style
+```
+
+- [ ] **Step 2: Read source files for accurate documentation**
+
+Read:
+- `atari_style/core/renderer.py` — all public methods for API reference
+- `atari_style/core/input_handler.py` — InputHandler and InputType for API reference
+- `atari_style/core/registry.py` — ContentRegistry, ContentMetadata, ContentCategory for API reference
+- `atari_style/core/config.py` — Config dataclass for API reference
+- `atari_style/utils/fonts.py` — load_monospace_font for API reference
+- `atari_style/main.py` — entry point and menu structure for architecture
+- `CLAUDE.md` — code conventions for contributor guide
+- `requirements.txt` — dependencies for getting started
+
+- [ ] **Step 3: Write Getting Started page**
+
+Create `docs/site/atari-style/getting-started.md` with Hugo front matter:
+```yaml
+---
+title: "Getting Started"
+weight: 1
+---
+```
+
+Content per spec: prerequisites, installation, first launch, "try these first" recommendations, troubleshooting.
+
+- [ ] **Step 4: Write Architecture Overview page**
+
+Create `docs/site/atari-style/architecture.md`:
+```yaml
+---
+title: "Architecture Overview"
+weight: 2
+---
+```
+
+Content: ASCII diagram of module relationships, Renderer explanation, InputHandler explanation, Menu + ContentRegistry, game loop pattern, module dependency map.
+
+- [ ] **Step 5: Write API Reference page**
+
+Create `docs/site/atari-style/api-reference.md`:
+```yaml
+---
+title: "API Reference"
+weight: 3
+---
+```
+
+Content: Renderer class (all public methods with type signatures, params, return values, examples), InputHandler class, Color constants, Config dataclass, ContentRegistry, load_monospace_font(). All documented from actual source code.
+
+- [ ] **Step 6: Write Building Your First Game tutorial**
+
+Create `docs/site/atari-style/tutorial.md`:
+```yaml
+---
+title: "Building Your First Game"
+weight: 4
+---
+```
+
+Content: Step-by-step bouncing ball demo. NOT Claugger — a simpler example. Covers: skeleton class, rendering, input, adding to menu. Points to Claugger source as "a more complete example."
+
+- [ ] **Step 7: Write Contributor Guide**
+
+Create `docs/site/atari-style/contributing.md`:
+```yaml
+---
+title: "Contributing"
+weight: 5
+---
+```
+
+Content: Dev setup, running tests, linting, code conventions, adding a new demo, PR process. Adapted from CLAUDE.md for human readers.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/site/atari-style/
+git commit -m "docs: Add 5-page project documentation for jcaldwell-labs.github.io"
+```
+
+---
+
+## Task 11: Publishing Workflow
+
+Create the GitHub Actions workflow that dispatches content to the Hugo site repo.
+
+**Files:**
+- Create: `.github/workflows/publish-docs.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/publish-docs.yml`:
+
+```yaml
+name: Publish Docs to Site
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/blog/**'
+      - 'docs/site/**'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine changed content
+        id: changes
+        run: |
+          blog_changed=false
+          docs_changed=false
+          if git diff --name-only HEAD~1 HEAD | grep -q '^docs/blog/'; then
+            blog_changed=true
+          fi
+          if git diff --name-only HEAD~1 HEAD | grep -q '^docs/site/'; then
+            docs_changed=true
+          fi
+          echo "blog=$blog_changed" >> "$GITHUB_OUTPUT"
+          echo "docs=$docs_changed" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch to site repo
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_PUBLISH_TOKEN }}
+          repository: jcaldwell-labs/jcaldwell-labs.github.io
+          event-type: publish-atari-style-docs
+          client-payload: |
+            {
+              "source_repo": "${{ github.repository }}",
+              "source_ref": "${{ github.sha }}",
+              "blog_changed": "${{ steps.changes.outputs.blog }}",
+              "docs_changed": "${{ steps.changes.outputs.docs }}"
+            }
+```
+
+- [ ] **Step 2: Verify workflow YAML is valid**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/publish-docs.yml'))"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/publish-docs.yml
+git commit -m "ci: Add cross-repo dispatch workflow for docs publishing"
+```
+
+---
+
+## Task 12: Final Integration + Verification
+
+Run full test suite, linter, and verify everything works together.
+
+**Files:** None new — verification only.
+
+- [ ] **Step 1: Run linter**
+
+```bash
+ruff check atari_style/ tests/
+```
+
+Expected: All checks passed.
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+python -m unittest discover -s tests -p "test_*.py" -v
+```
+
+Expected: All tests pass (existing + new claugger tests).
+
+- [ ] **Step 3: Smoke test Claugger from menu**
+
+```bash
+python run.py
+```
+
+Navigate to Games → Claugger. Verify:
+- Title screen renders with ASCII chicken
+- Game starts on ENTER
+- Chicken moves, vehicles scroll, river objects scroll
+- Collision kills chicken with death animation and pun message
+- River riding works (chicken moves with log)
+- Eggs appear randomly, can be squashed
+- HUD shows score, lives, timer
+- Filling all 5 nests completes level
+- Timer expiry kills chicken
+- Game over screen shows stats
+- ESC returns to menu cleanly
+
+- [ ] **Step 4: Verify article has real code snippets**
+
+Check that code blocks in `docs/blog/2026-03-19-claugger-terminal-arcade.md` match actual code in `atari_style/demos/games/claugger.py`. No placeholder or pseudo-code should remain.
+
+- [ ] **Step 5: Verify docs reference correct APIs**
+
+Check that method signatures in `docs/site/atari-style/api-reference.md` match the actual source files. Spot-check 3-4 methods.
+
+- [ ] **Step 6: Final commit if any fixes were needed**
+
+Review `git status` and stage only the specific files that were modified:
+
+```bash
+git status
+# Stage only the specific files that needed fixes:
+git add <specific-files-that-changed>
+git commit -m "fix: Final integration fixes for Claugger + docs"
+```
+
+---
+
+## Summary
+
+| Task | Description | Depends On |
+|------|-------------|------------|
+| 1 | Article outline | — |
+| 2 | Game skeleton + lanes | — |
+| 3 | Chicken sprite + movement | 2 |
+| 4 | Collision + death | 3 |
+| 5 | Scoring, lives, timer, HUD | 4 |
+| 6 | Egg-laying system | 5 |
+| 7 | Easter eggs + title/game over | 6 |
+| 8 | Menu registration + integration | 7 |
+| 9 | Blog article full draft | 1, 8 |
+| 10 | Project docs (5 pages) | 8 |
+| 11 | Publishing workflow | — |
+| 12 | Final verification | 9, 10, 11 |
+
+**Parallelizable:** Tasks 1 and 2 can run in parallel. Tasks 9, 10, and 11 can run in parallel after Task 8 completes.

--- a/docs/superpowers/specs/2026-03-19-claugger-article-docs-design.md
+++ b/docs/superpowers/specs/2026-03-19-claugger-article-docs-design.md
@@ -1,0 +1,308 @@
+# Design Spec: Claugger Game + Linux Journal Article + Project Docs
+
+**Date**: 2026-03-19
+**Status**: Approved
+**Issue**: #144 (Enhance project visibility and discoverability)
+
+---
+
+## Overview
+
+Three interconnected deliverables to boost atari-style's visibility and onboard new developers:
+
+1. **Claugger** — A Frogger-style terminal game starring an ASCII chicken
+2. **Blog article** — A late-90s Linux Journal-style manifesto + tutorial
+3. **Project documentation** — 5-page doc set published to jcaldwell-labs.github.io
+
+The article is the spine. The game exists to prove the article's thesis. The docs exist so readers who arrive via the article can go deeper.
+
+---
+
+## 1. Claugger — The Game
+
+### Concept
+
+"Why did the chicken cross the road?" — a Frogger clone with an over-the-top ASCII chicken, egg-laying bonuses, and chicken puns throughout. The name is a hat tip to Claude Code.
+
+### Gameplay
+
+**Layout** (13 logical lanes, bottom to top — each lane renders as 3 terminal rows to accommodate sprites):
+- Lane 1: Start zone (henhouse)
+- Lanes 2-6: Road lanes (vehicles scroll horizontally)
+- Lane 7: Safe median (sidewalk art)
+- Lanes 8-12: River lanes (logs and turtles scroll horizontally)
+- Lane 13: Goal zone (5 home nests to fill)
+
+Total playing field: ~39 terminal rows for lanes + 3 rows for HUD = 42 rows minimum. Requires terminal height of at least 44 rows (standard 80x24 won't suffice — game displays a "resize terminal" message if too small).
+
+**Core mechanics**:
+- Classic Frogger rules: hop across road, ride river objects, reach a nest
+- Fill all 5 nests to complete a level
+- 60-second timer per life (egg timer visual). Timer resets on death/respawn and on each new level. Does NOT reset when filling a nest mid-level.
+- 3 lives, level progression increases speeds
+- Wrap-around on screen edges for objects
+
+**Road hazards** (5 lanes):
+- Cars: 4-char ASCII sprites, colored
+- Trucks: 6-char ASCII sprites
+- Motorcycles: 2-char ASCII sprites
+- Each lane has independent speed and direction
+- Density increases with level
+
+**River objects** (5 lanes):
+- Logs: 5-8 char and 3-char variants
+- Turtles: groups of 2-3 (`@` characters), periodically dive (disappear for 2 seconds, resurface for 4 seconds — cycle is fixed per group but staggered across groups so not all dive simultaneously)
+- Chicken rides on objects, drowns if it falls in water
+- Lane speed and direction varies
+
+### The Chicken
+
+**Sprite**: 3x2 character multi-directional sprite with facing changes for up/down/left/right.
+
+**Animations**:
+- Walk cycle: 2-frame leg alternation
+- Idle: occasional head bob
+- Death (road): squashed flat (`___`), feathers scatter
+- Death (river): drowning splash (`~*~`), bubbles rise
+- Death (timeout): feathers fly (`' . ' .`), alarm sound via terminal bell
+
+### Egg-Laying Bonus
+
+- 5% chance per hop to lay an egg in the current lane. On river lanes, eggs are laid on the object the chicken is riding (log/turtle) and scroll with it. No eggs can be laid in water or on the safe median.
+- Eggs persist in the lane, worth 200 points if you complete the level
+- Eggs on road lanes can be squashed by vehicles (comic splat animation: `*`). Eggs on river objects fall in water if the object scrolls off-screen.
+- Collecting 10 eggs across the game awards an extra life
+- "EGGS-tra life!" message displayed
+
+### HUD & Personality
+
+- Score: "EGGS-cellent: 1,450"
+- Lives: `>Q< >Q< >Q<` (chicken face characters)
+- Level: "Crossing #3"
+- Timer: egg timer visual that drains
+- Death messages (rotating):
+  - "Fowl play!"
+  - "Chicken tender!"
+  - "Poultry in motion... denied!"
+  - "That's not how you cross the road!"
+  - "Hen-ded!"
+  - "Clucked out!"
+- Level complete: "Why did the chicken cross the road? FOR [score] POINTS!"
+- Game over: "THE ROOST IS COOKED" with final stats
+
+### Easter Eggs
+
+**1. The Konami Code**
+If the player enters Up-Up-Down-Down-Left-Right-Left-Right-SELECT-BACK (mapped to Enter-Esc on keyboard, Button 0-Button 1 on joystick) at the title screen or during gameplay pause, the chicken transforms into a golden rooster sprite for the remainder of the level. The golden rooster is invincible for 5 seconds, leaves a trail of golden eggs (500 points each), and the HUD briefly displays "COCKA-DOODLE-CHEAT!" The effect is one-time-use per game session.
+
+**2. The Road Scholar**
+If the player completes 3 levels without losing a single life, a brief ASCII diploma animation plays between levels: a scroll unfurls with "ROAD SCHOLAR" and the chicken wearing a tiny graduation cap. The HUD shows "Why did the chicken cross the road? To get to the other SIDE of knowledge!" and awards a 5,000 point bonus. This references both the joke and the Linux Journal educational spirit.
+
+### Technical Implementation
+
+- File: `atari_style/demos/games/claugger.py`
+- Class: `Claugger` with standard methods: `__init__()`, `draw()`, `update()`, `handle_input()`, `run()`
+- Entry function: `run_claugger()`
+- Uses `Renderer` and `InputHandler` from `atari_style.core`
+- Registered in `ContentRegistry` with: `id="claugger"`, `title="Claugger"`, `category=ContentCategory.GAME`, `description="Why did the chicken cross the road? A Frogger tribute."`, `run_module="atari_style.demos.games.claugger"`, `run_function_name="run_claugger"`
+- Added to menu in `main.py` in the Games section
+- Target: ~30 FPS (`time.sleep(0.033)`)
+- Full keyboard and joystick support
+- Collision model: bounding box on the chicken's full 3x2 sprite area. Any overlap between a hazard character and a chicken character is a hit. This makes the game slightly harder but feels fair given the chunky ASCII aesthetic.
+- Movement between lanes is instantaneous (snap to lane center). No intermediate hop animation that spans two lanes. The chicken is always fully in one lane for collision purposes. A brief 2-frame "hop" visual plays but the logical position updates atomically on the first frame.
+- Estimated size: ~900-1100 lines
+- Tests: `tests/test_claugger.py` covering lane scrolling, collision detection, egg mechanics, scoring, level progression, and easter egg triggers
+
+---
+
+## 2. Blog Article
+
+### Title
+
+*"Why Did the Chicken Cross the Terminal? Building Arcade Games Where Nobody Expected Them"*
+
+### Voice & Tone
+
+Late-1990s Linux Journal — practical, slightly irreverent, opinionated. Assumes the reader is comfortable with a terminal but doesn't assume game development experience. References: Larry Wall's Camel Book forewords, Marcel Gagne's Linux Journal columns, ESR's accessible technical writing.
+
+### Structure
+
+**1. Cold Open** (~200 words)
+Scene-setting. Reader boots a terminal, runs `python run.py`, and suddenly they're navigating a chicken across a highway. No X11. No Electron. Just blessed and a dream. Establishes the absurdity and the delight.
+
+**2. The Thesis: Terminals as Canvas** (~400 words)
+"The terminal is a canvas, not a cage." Draws from PHILOSOPHY.md principles. Historical context: nethack, the demoscene, ASCII art. Argument that constraints breed creativity — 80x24 is not a limitation, it's a format. References the broader atari-style project as proof.
+
+**3. The Toolkit** (~500 words)
+Introduces the two dependencies: blessed for rendering, pygame for joystick input. Explains why blessed over raw curses. Shows the Renderer abstraction (double buffering, color system, aspect ratio correction). Shows InputHandler (unified keyboard/joystick). Code snippets with commentary. References architecture docs: "For the full API, see [the docs]."
+
+**4. Building Claugger** (~1200 words)
+The centerpiece. Walks through building the game in stages:
+- The chicken sprite and walk cycle (ASCII art design, animation frames)
+- The lane system (data structures, scrolling mechanics)
+- Collision detection ("when poultry meets Pontiac")
+- The egg-laying bonus (random chance, persistence, scoring)
+- HUD with personality (puns, death messages, the egg timer)
+- Adding to the menu via ContentRegistry ("one import, one MenuItem, done")
+
+Each stage has code snippets — not the full source, but enough to understand the pattern. Readers are directed to the full source on GitHub.
+
+**5. The Bigger Picture** (~400 words)
+Zooms out. Shows how Claugger is one of 5+ games in the collection. Explains the modular architecture — every game follows the same pattern. Shows what else is in the project (Pac-Man, Galaga, Grand Prix, Breakout, creative tools, visual demos). Points to the docs for the contributor guide: "clone the repo, add your own game, submit a PR."
+
+**6. Closing** (~200 words)
+Why did the chicken cross the terminal? Because the terminal was always a gaming platform — we just forgot. Invitation to try the project, contribute, and remember that the best interfaces are the ones that make you smile. Something about chickens and open source.
+
+### Length
+
+~2500-3500 words total.
+
+### Format
+
+Hugo-compatible markdown with PaperMod front matter. Lives in `docs/blog/` in this repo. Filename uses the publication date (e.g., `2026-03-20-claugger-terminal-arcade.md`). The date is set when the article is finalized, not during drafting.
+
+### References to Docs
+
+The article links to docs at `https://jcaldwell-labs.github.io/docs/atari-style/`:
+- Architecture overview (from Section 3)
+- API reference (from Section 3)
+- "Building Your First Game" tutorial (from Section 4)
+- Contributor guide (from Section 5)
+
+---
+
+## 3. Project Documentation
+
+### Location
+
+`docs/site/atari-style/` in this repo. Published to `https://jcaldwell-labs.github.io/docs/atari-style/` via cross-repo dispatch.
+
+### Pages
+
+**1. Getting Started** (`getting-started.md`)
+- Prerequisites: Python 3.8+, terminal with color support
+- Installation: clone, venv, pip install, run
+- First launch: what you'll see (menu description)
+- "Try these first" recommendations (Starfield for visuals, Pac-Man for gameplay, Claugger for fun)
+- Troubleshooting: common issues (no joystick, terminal too small, missing fonts)
+
+**2. Architecture Overview** (`architecture.md`)
+- High-level diagram: core/ modules, demos/ structure, utils/
+- Renderer: double-buffered terminal output, color constants, drawing primitives
+- InputHandler: keyboard + joystick abstraction, deadzone handling, input types
+- Menu + ContentRegistry: how demos are discovered, registered, and launched
+- The game loop pattern: `__init__`, `update`, `draw`, `handle_input`, `run`
+- Module dependency map
+
+**3. API Reference** (`api-reference.md`)
+- `Renderer` class: all public methods with type signatures, parameters, return values, usage examples
+- `InputHandler` class: same treatment
+- `Color` enum/constants: full list with terminal color codes
+- `Config` dataclass: fields, validation rules, defaults
+- `ContentRegistry`: registration, discovery, category filtering
+- `load_monospace_font()`: utility function signature and usage
+
+**4. Building Your First Game** (`tutorial.md`)
+- Step-by-step: create a minimal bouncing ball demo
+- Start from the skeleton (class, methods, entry function)
+- Add rendering (draw a ball, move it, bounce off walls)
+- Add input (arrow keys change direction, ESC to quit)
+- Add to menu (import, MenuItem, done)
+- Next steps: points to Claugger source as "a more complete example"
+- Does NOT duplicate the blog article — this is a from-scratch tutorial for someone who hasn't read the article
+
+**5. Contributor Guide** (`contributing.md`)
+- Development setup (venv, pip install -e ., ruff)
+- Running tests: `python -m unittest discover -s tests -p "test_*.py" -v`
+- Linting: `ruff check atari_style/ tests/`
+- Code conventions: constants, imports, type hints, docstrings (adapted from CLAUDE.md for human readers)
+- Adding a new demo: step-by-step checklist
+- PR process: branch naming, commit messages, pre-commit checklist
+- Security requirements: HTML escaping, path validation, streaming
+
+### Format
+
+Hugo-compatible markdown with PaperMod front matter and section weights for navigation ordering.
+
+---
+
+## 4. Publishing Workflow
+
+### Mechanism
+
+Cross-repo `repository_dispatch` from atari-style to jcaldwell-labs.github.io.
+
+### Workflow: atari-style side
+
+File: `.github/workflows/publish-docs.yml`
+
+Triggers on push to `master` when `docs/blog/**` or `docs/site/**` change.
+
+Steps:
+1. Checkout atari-style repo
+2. Send `repository_dispatch` event to `jcaldwell-labs/jcaldwell-labs.github.io` with payload containing:
+   - Source repo and ref
+   - Which content changed (blog, docs, or both)
+
+Requires: A repository secret (`DOCS_PUBLISH_TOKEN`) containing a PAT with `repo` scope on the site repo.
+
+### Workflow: site repo side
+
+File: `.github/workflows/receive-content.yml` (in jcaldwell-labs.github.io — **out of scope for this project**; documented here for reference)
+
+Triggers on `repository_dispatch` event of type `publish-atari-style-docs`.
+
+Steps:
+1. Checkout site repo
+2. Checkout atari-style repo
+3. Copy `docs/blog/*.md` to `content/blog/`
+4. Copy `docs/site/atari-style/*.md` to `content/docs/atari-style/`
+5. Commit and push if changes exist
+6. Hugo build triggers automatically via existing site CI
+
+**Note**: This workflow must be created in the jcaldwell-labs.github.io repo separately. It is not a deliverable of this spec — only the atari-style side dispatch workflow is.
+
+### Fallback
+
+If the cross-repo dispatch isn't set up yet (missing PAT), docs can be manually copied. The workflow is a convenience, not a blocker for the content.
+
+---
+
+## 5. PR #143 Disposition
+
+- **Closed** on 2026-03-19 with explanation
+- **Backlog issue #161** created to hold the decision on reimplementation
+- No further action needed as part of this work
+
+---
+
+## 6. Easter Eggs (Surprise Elements)
+
+Two easter eggs are included in Claugger (detailed in Section 1 above):
+
+1. **The Konami Code** — Up-Up-Down-Down-Left-Right-Left-Right-SELECT-BACK triggers golden rooster mode with temporary invincibility and golden eggs
+2. **The Road Scholar** — Complete 3 levels without dying to earn a diploma animation and 5,000 point bonus
+
+These are designed to reward exploration and repeated play while fitting the comedic tone.
+
+---
+
+## Delivery Order (Article-Driven)
+
+1. **Article outline** — nail the narrative arc first
+2. **Claugger game** — build the game the article will walk through
+3. **Article draft** — write the full article with real code snippets from Claugger
+4. **Project docs** — write the 5 doc pages the article references
+5. **Publishing workflow** — GitHub Actions for cross-repo dispatch
+6. **Integration** — wire Claugger into menu/registry, final testing, commit everything
+
+---
+
+## Success Criteria
+
+- Claugger is playable, fun, and fits the existing game quality bar
+- Article reads like authentic late-90s Linux Journal content
+- A new developer can go from zero to contributing using only the docs
+- Blog post is published to jcaldwell-labs.github.io/blog/
+- Docs are published to jcaldwell-labs.github.io/docs/atari-style/
+- Issue #144 can be closed or substantially addressed

--- a/tests/test_claugger.py
+++ b/tests/test_claugger.py
@@ -50,5 +50,48 @@ class TestTerminalSize(unittest.TestCase):
         self.assertEqual(MIN_TERM_WIDTH, 80)
 
 
+class TestChicken(unittest.TestCase):
+    """Test chicken sprite and movement."""
+
+    def test_chicken_starts_at_lane_0(self):
+        """Chicken starts in the henhouse (lane 0, bottom)."""
+        game = Claugger()
+        self.assertEqual(game.chicken_lane, 0)
+
+    def test_chicken_moves_up(self):
+        """Moving up increments lane by 1."""
+        game = Claugger()
+        game.move_chicken(0, 1)
+        self.assertEqual(game.chicken_lane, 1)
+
+    def test_chicken_cannot_move_below_start(self):
+        """Chicken cannot move below lane 0."""
+        game = Claugger()
+        game.move_chicken(0, -1)
+        self.assertEqual(game.chicken_lane, 0)
+
+    def test_chicken_cannot_move_above_goal(self):
+        """Chicken cannot move above lane 12."""
+        game = Claugger()
+        game.chicken_lane = 12
+        game.move_chicken(0, 1)
+        self.assertEqual(game.chicken_lane, 12)
+
+    def test_chicken_horizontal_movement(self):
+        """Chicken can move left and right within screen bounds."""
+        game = Claugger()
+        start_x = game.chicken_x
+        game.move_chicken(1, 0)
+        self.assertGreater(game.chicken_x, start_x)
+
+    def test_chicken_has_facing_direction(self):
+        """Chicken facing changes with movement."""
+        game = Claugger()
+        game.move_chicken(0, 1)
+        self.assertEqual(game.chicken_facing, "up")
+        game.move_chicken(1, 0)
+        self.assertEqual(game.chicken_facing, "right")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_claugger.py
+++ b/tests/test_claugger.py
@@ -4,7 +4,7 @@ import random
 import unittest
 from atari_style.demos.games.claugger import (
     Lane, LaneType, LaneObject, Claugger,
-    LANE_COUNT, ROWS_PER_LANE,
+    LANE_COUNT, ROWS_PER_LANE, TURTLE_CHAR,
 )
 
 
@@ -91,6 +91,106 @@ class TestChicken(unittest.TestCase):
         self.assertEqual(game.chicken_facing, "up")
         game.move_chicken(1, 0)
         self.assertEqual(game.chicken_facing, "right")
+
+
+class TestCollision(unittest.TestCase):
+    """Test collision detection."""
+
+    def test_road_collision_kills_chicken(self):
+        """Chicken dies when overlapping a vehicle."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.chicken_lane = 1  # First road lane
+        game.lanes[1].objects[0].x = float(game.chicken_x)
+        game.check_collisions()
+        self.assertEqual(game.state, Claugger.STATE_DYING)
+
+    def test_no_collision_when_not_overlapping(self):
+        """Chicken is safe when no vehicle overlap."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.chicken_lane = 1
+        for obj in game.lanes[1].objects:
+            obj.x = -20.0
+        game.check_collisions()
+        self.assertNotEqual(game.state, Claugger.STATE_DYING)
+
+    def test_river_no_object_kills_chicken(self):
+        """Chicken drowns when on river lane without a log/turtle."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.chicken_lane = 7  # First river lane
+        for obj in game.lanes[7].objects:
+            obj.x = -50.0
+        game.check_collisions()
+        self.assertEqual(game.state, Claugger.STATE_DYING)
+
+    def test_river_on_log_is_safe(self):
+        """Chicken is safe when standing on a log."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.chicken_lane = 7
+        game.lanes[7].objects[0].x = float(game.chicken_x)
+        game.lanes[7].objects[0].width = 6
+        game.lanes[7].objects[0].is_diving = False
+        game.check_collisions()
+        self.assertNotEqual(game.state, Claugger.STATE_DYING)
+
+    def test_chicken_rides_log(self):
+        """Chicken moves with the log it's standing on."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.chicken_lane = 7
+        game.lanes[7].objects[0].x = float(game.chicken_x)
+        game.lanes[7].objects[0].width = 6
+        game.lanes[7].objects[0].is_diving = False
+        start_x = game.chicken_x
+        game.update_river_riding(0.5)
+        self.assertNotEqual(game.chicken_x, start_x)
+
+    def test_turtle_dive_kills_chicken(self):
+        """Chicken drowns when turtle it's on dives."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.chicken_lane = 7
+        turtle = game.lanes[7].objects[0]
+        turtle.x = float(game.chicken_x)
+        turtle.width = 3
+        turtle.is_diving = True
+        game.check_collisions()
+        self.assertEqual(game.state, Claugger.STATE_DYING)
+
+    def test_collision_uses_bounding_box(self):
+        """Collision checks full 3-wide sprite area."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.chicken_lane = 1
+        game.lanes[1].objects[0].x = float(game.chicken_x + 2)
+        game.lanes[1].objects[0].width = 4
+        game.check_collisions()
+        self.assertEqual(game.state, Claugger.STATE_DYING)
+
+    def test_turtle_dive_cycle_timing(self):
+        """Turtles dive for 2s and surface for 4s."""
+        game = Claugger()
+        # Find a turtle object
+        turtle = None
+        for lane in game.lanes:
+            if lane.lane_type == LaneType.RIVER:
+                for obj in lane.objects:
+                    if TURTLE_CHAR in obj.chars:
+                        turtle = obj
+                        break
+            if turtle:
+                break
+        if turtle is None:
+            self.skipTest("No turtle found")
+        # Force surface state and run through cycle
+        turtle.is_diving = False
+        turtle.dive_timer = 0.0
+        turtle.dive_phase = 4.0  # Surface duration
+        game.update_turtle_dives(4.0)
+        self.assertTrue(turtle.is_diving)
 
 
 if __name__ == "__main__":

--- a/tests/test_claugger.py
+++ b/tests/test_claugger.py
@@ -370,5 +370,22 @@ class TestEasterEggs(unittest.TestCase):
         self.assertEqual(game.score - score_before, 5000)
 
 
+class TestRegistration(unittest.TestCase):
+    """Test Claugger registration in ContentRegistry."""
+
+    def test_claugger_importable(self):
+        """run_claugger function is importable."""
+        from atari_style.demos.games.claugger import run_claugger
+        self.assertTrue(callable(run_claugger))
+
+    def test_claugger_in_registry(self):
+        """Claugger appears in the content registry."""
+        from atari_style.main import _build_registry
+        reg = _build_registry()
+        entry = reg.get("claugger")
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.title, "Claugger")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_claugger.py
+++ b/tests/test_claugger.py
@@ -3,7 +3,7 @@
 import random
 import unittest
 from atari_style.demos.games.claugger import (
-    Lane, LaneType, LaneObject, Claugger,
+    Lane, LaneType, LaneObject, Egg, Claugger,
     LANE_COUNT, ROWS_PER_LANE, TURTLE_CHAR,
 )
 
@@ -259,6 +259,64 @@ class TestScoring(unittest.TestCase):
         game.next_level()
         level2_speeds = [l.speed for l in game.lanes if l.lane_type == LaneType.ROAD]
         self.assertTrue(all(s2 > s1 for s1, s2 in zip(level1_speeds, level2_speeds)))
+
+
+class TestEggs(unittest.TestCase):
+    """Test egg-laying bonus system."""
+
+    def test_egg_not_laid_on_safe_median(self):
+        """No eggs on safe zones."""
+        game = Claugger()
+        game.chicken_lane = 6  # Safe median
+        game.try_lay_egg()
+        self.assertEqual(len(game.eggs), 0)
+
+    def test_egg_laid_on_road(self):
+        """Eggs can be laid on road lanes."""
+        game = Claugger()
+        game.chicken_lane = 1
+        game.lay_egg()
+        self.assertEqual(len(game.eggs), 1)
+        self.assertEqual(game.eggs[0].lane, 1)
+
+    def test_egg_on_river_has_attached_object(self):
+        """Eggs on river objects are attached to the object."""
+        game = Claugger()
+        game.chicken_lane = 7
+        # Place chicken on a log
+        log = game.lanes[7].objects[0]
+        log.x = float(game.chicken_x)
+        log.is_diving = False
+        game.lay_egg()
+        self.assertEqual(len(game.eggs), 1)
+        self.assertIsNotNone(game.eggs[0].attached_object)
+
+    def test_egg_squashed_by_vehicle(self):
+        """Vehicles destroy eggs on road lanes."""
+        game = Claugger()
+        game.chicken_lane = 1
+        game.lay_egg()
+        egg = game.eggs[0]
+        # Move a vehicle onto the egg
+        game.lanes[1].objects[0].x = egg.x
+        game.lanes[1].objects[0].width = 4
+        game.update_eggs(0.1)
+        self.assertTrue(egg.squashed)
+
+    def test_ten_eggs_award_extra_life(self):
+        """Collecting 10 eggs gives an extra life."""
+        game = Claugger()
+        game.total_eggs_laid = 9
+        game.lay_egg()
+        self.assertEqual(game.lives, 4)  # Started with 3
+
+    def test_eggs_award_points_on_level_complete(self):
+        """Surviving eggs are worth 200 points each on level complete."""
+        game = Claugger()
+        game.lay_egg_at(lane=1, x=10.0)
+        game.lay_egg_at(lane=2, x=20.0)
+        points = game.score_eggs()
+        self.assertEqual(points, 400)
 
 
 if __name__ == "__main__":

--- a/tests/test_claugger.py
+++ b/tests/test_claugger.py
@@ -6,6 +6,7 @@ from atari_style.demos.games.claugger import (
     Lane, LaneType, LaneObject, Egg, Claugger,
     LANE_COUNT, ROWS_PER_LANE, TURTLE_CHAR,
 )
+from atari_style.core.input_handler import InputType
 
 
 class TestLaneModel(unittest.TestCase):
@@ -317,6 +318,56 @@ class TestEggs(unittest.TestCase):
         game.lay_egg_at(lane=2, x=20.0)
         points = game.score_eggs()
         self.assertEqual(points, 400)
+
+
+class TestEasterEggs(unittest.TestCase):
+    """Test easter egg triggers."""
+
+    def test_konami_code_detection(self):
+        """Konami sequence activates golden rooster."""
+        game = Claugger()
+        sequence = [
+            InputType.UP, InputType.UP,
+            InputType.DOWN, InputType.DOWN,
+            InputType.LEFT, InputType.RIGHT,
+            InputType.LEFT, InputType.RIGHT,
+            InputType.SELECT, InputType.BACK,
+        ]
+        for inp in sequence:
+            game.record_input(inp)
+        self.assertTrue(game.golden_rooster_active)
+
+    def test_konami_code_single_use(self):
+        """Golden rooster can only be triggered once per session."""
+        game = Claugger()
+        game.golden_rooster_used = True
+        sequence = [
+            InputType.UP, InputType.UP,
+            InputType.DOWN, InputType.DOWN,
+            InputType.LEFT, InputType.RIGHT,
+            InputType.LEFT, InputType.RIGHT,
+            InputType.SELECT, InputType.BACK,
+        ]
+        for inp in sequence:
+            game.record_input(inp)
+        self.assertFalse(game.golden_rooster_active)
+
+    def test_road_scholar_triggers_after_3_deathless_levels(self):
+        """Road Scholar triggers after completing 3 levels without dying."""
+        game = Claugger()
+        game.consecutive_deathless_levels = 2
+        game.deaths_this_level = 0
+        game.next_level()
+        self.assertTrue(game.road_scholar_triggered)
+
+    def test_road_scholar_awards_bonus(self):
+        """Road Scholar awards 5000 points."""
+        game = Claugger()
+        game.consecutive_deathless_levels = 2
+        game.deaths_this_level = 0
+        score_before = game.score
+        game.next_level()
+        self.assertEqual(game.score - score_before, 5000)
 
 
 if __name__ == "__main__":

--- a/tests/test_claugger.py
+++ b/tests/test_claugger.py
@@ -193,5 +193,73 @@ class TestCollision(unittest.TestCase):
         self.assertTrue(turtle.is_diving)
 
 
+class TestScoring(unittest.TestCase):
+    """Test scoring, lives, and level progression."""
+
+    def test_initial_score_is_zero(self):
+        game = Claugger()
+        self.assertEqual(game.score, 0)
+
+    def test_initial_lives_is_three(self):
+        game = Claugger()
+        self.assertEqual(game.lives, 3)
+
+    def test_forward_hop_awards_points(self):
+        """Moving forward awards 10 points per new lane."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.move_chicken(0, 1)
+        self.assertEqual(game.score, 10)
+
+    def test_reaching_nest_awards_bonus(self):
+        """Filling a nest awards 50 points + time bonus."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.chicken_lane = 12
+        game.fill_nest()
+        self.assertGreater(game.score, 50)
+
+    def test_five_nests_completes_level(self):
+        """Filling all 5 nests triggers level complete."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.nests_filled = 4
+        game.chicken_lane = 12
+        game.fill_nest()
+        self.assertEqual(game.state, Claugger.STATE_LEVEL_COMPLETE)
+
+    def test_timer_resets_on_death(self):
+        """Timer resets when chicken respawns."""
+        game = Claugger()
+        game.timer = 30.0
+        game._respawn_chicken()
+        self.assertEqual(game.timer, 60.0)
+
+    def test_timer_does_not_reset_on_nest_fill(self):
+        """Timer keeps running when a nest is filled mid-level."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.timer = 30.0
+        game.chicken_lane = 12
+        game.fill_nest()
+        self.assertLessEqual(game.timer, 30.0)
+
+    def test_timer_expiry_kills_chicken(self):
+        """Chicken dies when timer reaches zero."""
+        game = Claugger()
+        game.state = Claugger.STATE_PLAYING
+        game.timer = 0.01
+        game.update(0.02)
+        self.assertEqual(game.state, Claugger.STATE_DYING)
+
+    def test_level_progression_increases_speed(self):
+        """Higher levels have faster lane speeds."""
+        game = Claugger()
+        level1_speeds = [l.speed for l in game.lanes if l.lane_type == LaneType.ROAD]
+        game.next_level()
+        level2_speeds = [l.speed for l in game.lanes if l.lane_type == LaneType.ROAD]
+        self.assertTrue(all(s2 > s1 for s1, s2 in zip(level1_speeds, level2_speeds)))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_claugger.py
+++ b/tests/test_claugger.py
@@ -1,0 +1,54 @@
+"""Tests for Claugger game."""
+
+import random
+import unittest
+from atari_style.demos.games.claugger import (
+    Lane, LaneType, LaneObject, Claugger,
+    LANE_COUNT, ROWS_PER_LANE,
+)
+
+
+class TestLaneModel(unittest.TestCase):
+    """Test lane data structures."""
+
+    def test_lane_count(self):
+        """13 logical lanes in the game."""
+        self.assertEqual(LANE_COUNT, 13)
+
+    def test_rows_per_lane(self):
+        """Each lane renders as 3 terminal rows."""
+        self.assertEqual(ROWS_PER_LANE, 3)
+
+    def test_road_lane_creation(self):
+        """Road lane has correct type and direction."""
+        lane = Lane(lane_type=LaneType.ROAD, speed=2.0, direction=1)
+        self.assertEqual(lane.lane_type, LaneType.ROAD)
+        self.assertEqual(lane.direction, 1)
+
+    def test_lane_object_wraps(self):
+        """Objects wrap around when they scroll past screen edge."""
+        obj = LaneObject(x=78.0, width=4, chars="AUTO")
+        obj.x += 3  # Push past 80-col screen
+        screen_width = 80
+        if obj.x >= screen_width:
+            obj.x = -obj.width
+        self.assertEqual(obj.x, -4)
+
+    def test_river_lane_creation(self):
+        """River lane has correct type."""
+        lane = Lane(lane_type=LaneType.RIVER, speed=1.5, direction=-1)
+        self.assertEqual(lane.lane_type, LaneType.RIVER)
+
+
+class TestTerminalSize(unittest.TestCase):
+    """Test terminal size requirements."""
+
+    def test_min_dimensions_constants(self):
+        """Game defines minimum terminal dimensions."""
+        from atari_style.demos.games.claugger import MIN_TERM_HEIGHT, MIN_TERM_WIDTH
+        self.assertEqual(MIN_TERM_HEIGHT, 44)
+        self.assertEqual(MIN_TERM_WIDTH, 80)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Claugger game** — Frogger-style terminal game with ASCII chicken, egg-laying bonuses, Konami Code easter egg, Road Scholar achievement (1,184 lines, 41 tests)
- **Blog article** — Late-90s Linux Journal manifesto + tutorial: "Why Did the Chicken Cross the Terminal?" (~2,500 words, real code snippets)
- **Project docs** — 5-page doc set for jcaldwell-labs.github.io (getting-started, architecture, API reference, tutorial, contributing)
- **Publish workflow** — GitHub Actions cross-repo dispatch to Hugo site repo

Closes #144

## Details

### Claugger (`atari_style/demos/games/claugger.py`)
- 13-lane Frogger layout: road vehicles, river logs/turtles, 5 home nests
- 3x2 ASCII chicken sprite with directional facing and walk animation
- Collision: bounding box, road squash, river drowning, turtle diving (2s/4s cycle)
- Scoring: 10pts/lane, 50pts + time bonus per nest, 200pts/surviving egg
- Egg-laying: 5% chance per hop, road squashing, river scrolling, EGGS-tra life every 10
- Easter eggs: Konami Code golden rooster (5s invincibility), Road Scholar (3 deathless levels = 5000pt diploma)
- HUD: "EGGS-cellent" score, egg timer bar, rotating death puns
- Registered in ContentRegistry and main menu

### Blog Article (`docs/blog/2026-03-19-claugger-terminal-arcade.md`)
- Voice: practical, irreverent, opinionated — authentic Linux Journal circa 1998
- Structure: cold open → thesis (terminals as canvas) → toolkit → building Claugger → bigger picture → closing
- 11 real code blocks from the codebase

### Project Docs (`docs/site/atari-style/`)
- Getting Started, Architecture Overview, API Reference, Building Your First Game tutorial, Contributing guide
- API reference documents all public methods from Renderer, InputHandler, ContentRegistry, Config, Color

### Publish Workflow (`.github/workflows/publish-docs.yml`)
- Triggers on push to master when `docs/blog/**` or `docs/site/**` change
- Sends `repository_dispatch` to jcaldwell-labs.github.io
- Requires `DOCS_PUBLISH_TOKEN` secret (not yet configured)

## Test plan

- [x] `ruff check atari_style/ tests/` — all checks passed
- [x] 41 Claugger-specific tests pass (lanes, collision, scoring, eggs, easter eggs, registration)
- [x] Full suite: 409/411 pass (2 pre-existing import failures unrelated to this PR)
- [ ] Smoke test: `python -c "from atari_style.demos.games.claugger import run_claugger; run_claugger()"` — verify title screen, gameplay, death animations, HUD
- [ ] Verify article code snippets match actual source
- [ ] Configure `DOCS_PUBLISH_TOKEN` secret after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)