### PR TITLE
docs: Architecture guide — demo engine first (resolves #155)

### DIFF
--- a/.github/planning/tech-debt-workplan.md
+++ b/.github/planning/tech-debt-workplan.md
@@ -1,0 +1,48 @@
+# Tech Debt Workplan
+
+Prioritized plan for resolving open tech debt issues, sequenced by dependency and impact.
+Created 2026-03-17 from analysis of issues #149-#155.
+Updated 2026-06-10: reconciled with actual state — the 2026-03-19 sprint closed most of this.
+
+## Status Key
+- [ ] Not started
+- [x] Complete
+- [~] In progress
+
+## Tier 1 — Independent, high value (no architecture decision needed)
+
+- [x] **#149** — Replace bare except clauses with specific exception types (closed 2026-03-19, PR #158)
+- [x] **#151** — Create shared font loading utility (closed 2026-03-19, PR #160)
+
+## Tier 2 — Strategic decision (unblocks Tier 3)
+
+- [x] **#155** — Architecture guide: resolved 2026-06-10, see /ARCHITECTURE.md
+  - Decided: `atari_style/` is canonical; `terminal_arcade/` deprecated, games kept as read-only content
+  - Decided: GL pipeline and terminal renderer are permanent peers (video output vs interactive)
+  - Decided: plugin system kept dormant, not required for new features
+
+## Tier 3 — Was blocked by #155
+
+- [x] **#150** — Duplicate InputHandler (closed 2026-03-19; resolved by deprecating
+      terminal_arcade rather than extracting a shared module — atari_style copy is canonical)
+- [x] **#152** — Duplicate buffer handling (closed 2026-03-19 as architectural:
+      terminal and GL renderers have distinct buffer concerns, no shared base class needed)
+
+## Tier 4 — Lower priority
+
+- [x] **#153** — Add validation to Config dataclass (closed 2026-03-19, PR #157)
+- [x] **#154** — Optimize inefficient loop patterns (closed 2026-03-19, PR #159)
+- [x] **#144** — Enhance project visibility and discoverability (closed 2026-03-20)
+
+## Remaining open work
+
+- [ ] **#161** — Revisit zone mode for shader embedding (decision needed: is there a
+      downstream consumer, e.g. my-grid? If yes, fresh PR on ContentRegistry with
+      safer IPC than TCP setattr — see issue for blockers found in PR #143 review)
+- [ ] terminal_arcade migration end-state: port games out opportunistically (see ARCHITECTURE.md §1)
+
+## Content pipeline notes (June 2026)
+
+Channel analytics review (25 videos, ~1.3k views) established the publishing profile:
+bright/saturated > dark/sparse; recognizable subjects; <60s; no shell chrome in frame;
+end on the strongest frame. Codified in ARCHITECTURE.md §6.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,139 @@
+# Architecture Guide
+
+Decision record resolving the structural questions in issue #155. This is the
+"I want to add X — where does it go?" reference for contributors (human and AI).
+
+**Last updated:** 2026-06-10
+
+## Project Identity
+
+atari-style started as a collection of retro game clones. That is no longer the
+center of gravity. The project's primary product is a **parametric visualization
+engine**: animations with live-adjustable parameters (keyboard/joystick), a
+GPU shader pipeline with cross-modulated composites and post-processing, and a
+video export toolchain that feeds the @jcaldwell-labs YouTube channel.
+
+Games remain as content and examples — they exercise the renderer, input
+handling, and registry — but new investment should default to the engine,
+visualizers, and video tooling.
+
+```
+                         ┌─────────────────────────┐
+                         │      ContentRegistry     │  ← single discovery point
+                         └───────────┬─────────────┘
+              ┌──────────────────────┼──────────────────────┐
+        visualizers (primary)   games (content)        tools (utility)
+              │                      │                      │
+   ┌──────────┴──────────┐    terminal renderer       terminal renderer
+   │                     │    (blessed, interactive)
+ GL pipeline       terminal renderer
+ (moderngl,        (blessed, interactive)
+  video export)
+```
+
+## Decisions
+
+### 1. `atari_style/` is the canonical package
+
+`terminal_arcade/` is **deprecated** (its `main` already warns). Disposition:
+
+- All new code goes in `atari_style/`.
+- `terminal_arcade/games/` remains a **read-only content source**: its per-game
+  directories with `metadata.json` are auto-discovered by `ContentRegistry` at
+  startup (`atari_style/main.py`). Treat them as data, not code.
+- `terminal_arcade/engine/` and `terminal_arcade/launcher/` receive no fixes.
+  Known divergences (e.g., its `input_handler.py` still has a bare `except`
+  that was fixed in `atari_style` by #158) are intentionally left as-is.
+- Migration end-state: when a `terminal_arcade` game needs real work, port it
+  to `atari_style/demos/games/` and delete the original.
+
+**Rationale:** `atari_style/` has all active development (GL pipeline, video
+tooling, plugins, ContentRegistry, 150+ commits in 2026 vs. zero meaningful
+ones in `terminal_arcade/`), and `ContentRegistry` (issue #156) already
+subsumed the one good idea in `terminal_arcade` — metadata-driven discovery.
+
+### 2. GL pipeline and terminal renderer are permanent peers
+
+They serve different outputs and neither replaces the other:
+
+| | Terminal renderer (`core/renderer.py`) | GL pipeline (`core/gl/`) |
+|---|---|---|
+| Output | live interactive terminal | offscreen frames → video/GIF/thumbnails |
+| Strengths | input loops, menus, games, in-terminal demos | per-pixel math, composites, post-FX (CRT/ASCII/phosphor), 1080p+ |
+| Use when | a human plays/explores it live | the result is a rendered artifact |
+
+A concept may exist in both (e.g., plasma has a terminal mode and a GL shader).
+That duplication is acceptable — they are different renderings of the same
+idea, not duplicated infrastructure. Shared logic (parameter definitions,
+palettes) belongs in `core/`.
+
+### 3. Where new content goes
+
+| Adding… | Location | Registration |
+|---|---|---|
+| Visualizer (terminal) | `atari_style/demos/visualizers/` | register in `main.py` via ContentRegistry (lazy, string-based) |
+| GL shader effect | `atari_style/shaders/effects/*.frag` + `CompositeConfig` entry in `core/gl/composites.py` | auto-discovered by CompositeManager |
+| Game | `atari_style/demos/games/` | ContentRegistry in `main.py` |
+| Tool | `atari_style/demos/tools/` | ContentRegistry in `main.py` |
+| Post-processing effect | `atari_style/shaders/post/*.frag` + wire into `core/gl/pipeline.py` | — |
+
+New visualizers should implement the `ParametricAnimation` protocol
+(`adjust_params`, `get_param_info`, see `demos/visualizers/screensaver.py`):
+**live parameter control is the product**, not an optional nicety.
+
+### 4. Plugin system: keep, dormant
+
+`atari_style/plugins/` (schema, loader, discovery, CLI) is complete but has no
+runtime consumer — `ContentRegistry.bridge_all_plugins()` exists and is never
+called. Decision:
+
+- Do **not** require new features to be plugins.
+- Do not delete it: the schema is the extension point for third-party shaders
+  if/when there's an external consumer (see #161 zone-mode discussion).
+- Wire `bridge_all_plugins()` into startup only when the first real plugin exists.
+
+### 5. Testing conventions
+
+- New tests go in `tests/` (pytest/unittest discoverable as `test_*.py`).
+- Root-level `test_*.py` files are legacy; migrate opportunistically, don't add.
+- Visualizers: headless smoke test via `headless_renderer.py` (renders N frames,
+  asserts no exception and non-empty buffer). Visual-regression baselines in
+  `baselines/` are best-effort, not CI-gating.
+- GL composites: a render test that exports 1 frame per composite is sufficient
+  (catches shader compile errors on llvmpipe).
+
+### 6. Video pipeline is load-bearing
+
+The video toolchain (`core/gl/video_export.py`, `core/demo_video.py`,
+`core/video_script.py` + CLI, `core/showcase.py`, storyboards) is **not** an
+experiment — it is the publishing pipeline for the YouTube channel and a core
+part of the engine identity.
+
+- A new GL composite should be exportable via
+  `python -m atari_style.core.gl.video_export <name>` on the day it lands.
+- Content guidance for published videos (derived from channel analytics,
+  June 2026): bright/saturated beats dark/sparse, recognizable subjects beat
+  abstract ones, under 60s, never include shell chrome, end on the strongest
+  frame. See `.github/planning/` for the working notes.
+- Storyboards (`storyboards/*.json`) are optional; use them for multi-segment
+  videos, not single-composite exports.
+
+## Quick decision tree
+
+```
+I want to add…
+├─ a visual effect rendered to video        → GL shader + CompositeConfig (§3)
+├─ an interactive in-terminal experience    → demos/visualizers/ + ParametricAnimation (§3)
+├─ a game                                   → demos/games/ + ContentRegistry (§3)
+├─ a post-processing look (CRT, ASCII…)     → shaders/post/ + pipeline.py (§3)
+├─ a fix to terminal_arcade                 → don't; port the game out instead (§1)
+└─ a plugin                                 → not yet; open an issue first (§4)
+```
+
+## Related
+
+- Issue #155 (this document resolves it)
+- Issue #161 — zone mode reimplementation (open decision; any new attempt
+  should use ContentRegistry and a safer IPC than raw TCP `setattr`)
+- `docs/architecture.md` — historical pre-GL rendering analysis (kept for context)
+- `PHILOSOPHY.md` — design principles


### PR DESCRIPTION
## Summary
- Adds top-level **ARCHITECTURE.md** resolving all six questions from #155:
  - `atari_style/` is canonical; `terminal_arcade/` deprecated, its games kept as read-only auto-discovered content
  - GL pipeline and terminal renderer are **permanent peers** (rendered artifacts vs interactive experiences)
  - Content placement decision tree (visualizers / shaders / games / tools / post-FX)
  - Plugin system kept but dormant — not required for new features
  - Testing conventions (tests/ canonical, headless smoke tests for visualizers)
  - Video pipeline declared **load-bearing** (it's the YouTube publishing path), with content guidance derived from June 2026 channel analytics
- Repositions project identity: **parametric demo engine first, games as content** — matching where development actually went (GL pipeline, ContentRegistry, video tooling)
- Reconciles `.github/planning/tech-debt-workplan.md` with reality: #149–#154 were closed in the 2026-03-19 sprint; remaining open work is #161 (zone mode decision) and opportunistic terminal_arcade migration

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)